### PR TITLE
Update to use `stylelint-config-wordpress` shared `stylelint` configuration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,10 @@ module.exports = function(grunt) {
 
 		BP_NTP_JS = [
 			'**/*.js'
-		];
+		],
+
+		stylelintConfigCss  = require('stylelint-config-wordpress/index.js'),
+		stylelintConfigScss = require('stylelint-config-wordpress/scss.js');
 
 	require( 'matchdep' ).filterDev( 'grunt-*' ).forEach( grunt.loadNpmTasks );
 
@@ -76,7 +79,7 @@ module.exports = function(grunt) {
 		stylelint: {
 			css: {
 				options: {
-					configFile: '.stylelintrc',
+					config: stylelintConfigCss,
 					format: 'css'
 				},
 				expand: true,
@@ -90,16 +93,16 @@ module.exports = function(grunt) {
 			},
 			scss: {
 				options: {
-					configFile: '.stylelintrc',
+					config: stylelintConfigScss,
 					format: 'scss'
 				},
 				expand: true,
 				cwd: WORKING_DIR,
 				src: [
 					'bp-nouveau/sass/buddypress.scss',
-				'common-styles/*.scss',
-				'!common-styles/_bp-mixins.scss',
-				'!common-styles/_bp-variables.scss'
+					'common-styles/*.scss',
+					'!common-styles/_bp-mixins.scss',
+					'!common-styles/_bp-variables.scss'
 				]
 			}
 		},
@@ -120,7 +123,7 @@ module.exports = function(grunt) {
 	});
 
 	// Lint CSS & JavaScript
-	grunt.registerTask( 'lint', ['jshint', 'stylelint' ] );
+	grunt.registerTask( 'lint', ['stylelint', 'jshint' ] );
 
 	// Build CSS & JavaScript
 	grunt.registerTask( 'build', [ 'sass', 'rtlcss' ] );

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "grunt-stylelint": "^0.7.0",
     "matchdep": "~1.0.1",
     "postcss-scss": "0.4.1",
-    "stylelint": "~7.10.1"
+    "stylelint": "~7.10.1",
+    "stylelint-config-wordpress": "^10.0.1"
   },
   "engines": {
     "node": ">=6.9.1"


### PR DESCRIPTION
• This allows us to utilise both the CSS and SCSS configurations of `stylelint-config-wordpress`