### PR TITLE
Add <div id="buddypress"> wrapper container dynamically.

### DIFF
--- a/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/bp-templates/bp-nouveau/buddypress-functions.php
@@ -172,6 +172,9 @@ class BP_Nouveau extends BP_Theme_Compat {
 		// Filter BuddyPress template hierarchy and look for page templates.
 		add_filter( 'bp_get_buddypress_template', array( $this, 'theme_compat_page_templates' ), 10, 1 );
 
+		// Add our "buddypress" div wrapper to theme compat template parts.
+		add_filter( 'bp_replace_the_content', array( $this, 'theme_compat_wrapper' ), 999 );
+
 		// We need to neutralize the BuddyPress core "bp_core_render_message()" once it has been added.
 		add_action( 'bp_actions', array( $this, 'neutralize_core_template_notices' ), 6 );
 
@@ -567,6 +570,26 @@ class BP_Nouveau extends BP_Theme_Compat {
 		}
 
 		return $templates;
+	}
+
+	/**
+	 * Add our special 'buddypress' div wrapper to the theme compat template part.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @see bp_buffer_template_part()
+	 *
+	 * @param  string $retval Current template part contents.
+	 * @return string
+	 */
+	public function theme_compat_wrapper( $retval ) {
+		// We already have a 'buddypress' wrapper, so bail.
+		if ( false !== strpos( $retval, '<div id="buddypress"' ) ) {
+			return $retval;
+		}
+
+		// Add our 'buddypress' div wrapper.
+		return sprintf( '<div id="buddypress" class="%1$s">%2$s</div><!-- #buddypress -->%3$s', bp_nouveau_get_buddypress_classes(), $retval, "\n" );
 	}
 
 	/**

--- a/bp-templates/bp-nouveau/buddypress/activity/index.php
+++ b/bp-templates/bp-nouveau/buddypress/activity/index.php
@@ -9,8 +9,6 @@
  */
 ?>
 
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
-
 	<?php bp_nouveau_before_activity_directory_content(); ?>
 
 	<?php if ( is_user_logged_in() ) : ?>
@@ -46,4 +44,3 @@
 		<?php bp_nouveau_after_activity_directory_content() ;?>
 	</div><!-- // .screen-content -->
 
-</div>

--- a/bp-templates/bp-nouveau/buddypress/activity/single/home.php
+++ b/bp-templates/bp-nouveau/buddypress/activity/single/home.php
@@ -7,7 +7,6 @@
  */
 
 ?>
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
 
 	<?php bp_nouveau_template_notices(); ?>
 
@@ -20,4 +19,3 @@
 		</ul>
 
 	</div>
-</div>

--- a/bp-templates/bp-nouveau/buddypress/blogs/index.php
+++ b/bp-templates/bp-nouveau/buddypress/blogs/index.php
@@ -8,8 +8,6 @@
  */
 ?>
 
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
-
 	<?php bp_nouveau_before_blogs_directory_content() ;?>
 
 	<?php if ( ! bp_nouveau_is_object_nav_in_sidebar() ) : ?>
@@ -29,4 +27,3 @@
 		<?php bp_nouveau_after_blogs_directory_content() ;?>
 	</div><!-- // .screen-content -->
 
-</div><!-- //.buddypress -->

--- a/bp-templates/bp-nouveau/buddypress/groups/create.php
+++ b/bp-templates/bp-nouveau/buddypress/groups/create.php
@@ -8,8 +8,6 @@
 
 bp_nouveau_groups_create_hook( 'before', 'page' ); ?>
 
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
-
 	<h2 class="bp-subhead"><?php _e('Create A New Group','bp-nouveau'); ?></h2>
 
 	<?php bp_nouveau_groups_create_hook( 'before', 'content_template' ); ?>
@@ -39,7 +37,5 @@ bp_nouveau_groups_create_hook( 'before', 'page' ); ?>
 	</form>
 
 	<?php bp_nouveau_groups_create_hook( 'after', 'content_template' ); ?>
-
-</div>
 
 <?php bp_nouveau_groups_create_hook( 'after', 'page' );

--- a/bp-templates/bp-nouveau/buddypress/groups/index.php
+++ b/bp-templates/bp-nouveau/buddypress/groups/index.php
@@ -8,8 +8,6 @@
  */
 ?>
 
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
-
 	<?php bp_nouveau_before_groups_directory_content(); ?>
 
 	<?php bp_nouveau_template_notices(); ?>
@@ -31,4 +29,3 @@
 	<?php bp_nouveau_after_groups_directory_content(); ?>
 	</div><!-- // .screen-content -->
 
-</div><!-- //.buddypress -->

--- a/bp-templates/bp-nouveau/buddypress/groups/single/home.php
+++ b/bp-templates/bp-nouveau/buddypress/groups/single/home.php
@@ -8,7 +8,6 @@
  */
 
 ?>
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
 
 	<?php if ( bp_has_groups() ) : while ( bp_groups() ) : bp_the_group(); ?>
 
@@ -39,5 +38,3 @@
 		<?php bp_nouveau_group_hook( 'after', 'home_content' ); ?>
 
 	<?php endwhile; endif; ?>
-
-</div><!-- #buddypress -->

--- a/bp-templates/bp-nouveau/buddypress/members/activate.php
+++ b/bp-templates/bp-nouveau/buddypress/members/activate.php
@@ -8,8 +8,6 @@
 
 ?>
 
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
-
 	<?php bp_nouveau_activation_hook( 'before', 'page' ); ?>
 
 	<div class="page" id="activate-page">
@@ -49,4 +47,3 @@
 
 	<?php bp_nouveau_activation_hook( 'after', 'page' ); ?>
 
-</div><!-- #buddypress -->

--- a/bp-templates/bp-nouveau/buddypress/members/index.php
+++ b/bp-templates/bp-nouveau/buddypress/members/index.php
@@ -9,8 +9,6 @@
 
 ?>
 
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
-
 	<?php bp_nouveau_before_members_directory_content() ?>
 
 	<?php if ( ! bp_nouveau_is_object_nav_in_sidebar() ) : ?>
@@ -29,5 +27,3 @@
 
 		<?php bp_nouveau_after_members_directory_content() ?>
 	</div><!-- // .screen-content -->
-
-</div><!-- //.buddypress -->

--- a/bp-templates/bp-nouveau/buddypress/members/register.php
+++ b/bp-templates/bp-nouveau/buddypress/members/register.php
@@ -9,8 +9,6 @@
 
 ?>
 
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
-
 	<?php bp_nouveau_signup_hook( 'before', 'page' ); ?>
 
 	<div id="register-page"class="page register-page">
@@ -123,5 +121,3 @@
 	</div>
 
 	<?php bp_nouveau_signup_hook( 'after', 'page' ); ?>
-
-</div><!-- #buddypress -->

--- a/bp-templates/bp-nouveau/buddypress/members/single/home.php
+++ b/bp-templates/bp-nouveau/buddypress/members/single/home.php
@@ -9,8 +9,6 @@
 
 ?>
 
-<div id="buddypress" class="<?php bp_nouveau_buddypress_classes(); ?>">
-
 	<?php bp_nouveau_member_hook( 'before', 'home_content' ); ?>
 
 	<div id="item-header" role="complementary" data-bp-item-id="<?php echo bp_displayed_user_id(); ?>" data-bp-item-component="members" class="users-header single-headers">
@@ -34,5 +32,3 @@
 	</div><!-- // .bp-wrap -->
 
 	<?php bp_nouveau_member_hook( 'after', 'home_content' ); ?>
-
-</div><!-- #buddypress -->


### PR DESCRIPTION
So in a few template parts of ours, we add the `<div id="buddypress">` wrapper container.

I think this shouldn't be necessary; we can do this dynamically on the `'bp_replace_the_content'` filter hook when BP's Theme Compatibility API kicks in.  This ensures that we add our wrapper only when needed.

What do you think?