### PR TITLE
Fixes #155 in cover-image-header.php

### DIFF
--- a/bp-templates/bp-nouveau/buddypress/groups/single/cover-image-header.php
+++ b/bp-templates/bp-nouveau/buddypress/groups/single/cover-image-header.php
@@ -44,7 +44,7 @@
 			<?php bp_nouveau_group_header_buttons(); ?>
 
 		</div><!-- #item-header-content -->
-<?php endif; ?><!--if front page description option is set and the meta is not loaded -->
+<?php endif; ?>
 
 		<?php bp_get_template_part('groups/single/parts/header-item-actions'); ?>
 

--- a/bp-templates/bp-nouveau/buddypress/groups/single/cover-image-header.php
+++ b/bp-templates/bp-nouveau/buddypress/groups/single/cover-image-header.php
@@ -22,6 +22,7 @@
 			</div><!-- #item-header-avatar -->
 		<?php endif; ?>
 
+<?php	if ( ! bp_nouveau_groups_front_page_description() ) : ?>
 		<div id="item-header-content">
 
 
@@ -43,6 +44,7 @@
 			<?php bp_nouveau_group_header_buttons(); ?>
 
 		</div><!-- #item-header-content -->
+<?php endif; ?><!--if front page description option is set and the meta is not loaded -->
 
 		<?php bp_get_template_part('groups/single/parts/header-item-actions'); ?>
 
@@ -51,6 +53,7 @@
 
 </div><!-- #cover-image-container -->
 
+<?php	if ( ! bp_nouveau_groups_front_page_description() ) : ?>
 <?php if( bp_nouveau_group_meta()->description ) { ?>
 	<div class="desc-wrap">
 		<div class="group-description">
@@ -58,3 +61,4 @@
 	</div><!-- //.group_description -->
 </div>
 <?php	} ?>
+<?php endif; ?>


### PR DESCRIPTION
Fixes #155, by removing meta display when " Display the Group's description in the front page body." 
Since the meta information is not initialized when this option is set, it produces error notices.

[shouldn't the meta information also be added to the Front page along with the description in this case]