### PR TITLE
HTML `<a>` elements should never have `title` attributes.

### DIFF
--- a/bp-templates/bp-nouveau/buddypress/_accessoires/invites/index.php
+++ b/bp-templates/bp-nouveau/buddypress/_accessoires/invites/index.php
@@ -41,7 +41,7 @@
 					<ul class="group-inviters">
 						<li><?php esc_html_e( 'Invited by:', 'buddypress' ); ?></li>
 						<# for ( i in data.invited_by ) { #>
-							<li><a href="{{data.invited_by[i].user_link}}" class="bp-tooltip" data-bp-tooltip="{{data.invited_by[i].user_name}}"><img src="{{data.invited_by[i].avatar}}" width="30px" class="avatar mini" alt="{{data.invited_by[i].user_name}}"></a></li>
+							<li><a href="{{data.invited_by[i].user_link}}"><img src="{{data.invited_by[i].avatar}}" width="30px" class="avatar mini" alt="{{data.invited_by[i].user_name}}"></a></li>
 						<# } #>
 					</ul>
 				<# } #>
@@ -75,7 +75,7 @@
 </script>
 
 <script type="text/html" id="tmpl-bp-invites-selection">
-	<a href="#" title="{{data.name}}">
+	<a href="#"">
 		<img src="{{data.avatar}}" class="avatar" alt="{{data.name}}" />
 	</a>
 </script>
@@ -106,13 +106,13 @@
 
 <script type="text/html" id="tmpl-bp-invites-paginate">
 	<# if ( 1 !== data.page ) { #>
-		<a href="#" id="bp-invites-prev-page" title="<?php esc_attr_e( 'Prev', 'buddypress' );?>" class="button invite-button">
+		<a href="#" id="bp-invites-prev-page" class="button invite-button">
 			<span class="bp-screen-reader-text"><?php esc_html_e( 'Prev', 'buddypress' );?></span>
 		</a>
 	<# } #>
 
 	<# if ( data.total_page !== data.page ) { #>
-		<a href="#" id="bp-invites-next-page" title="<?php esc_attr_e( 'Next', 'buddypress' );?>" class="button invite-button">
+		<a href="#" id="bp-invites-next-page" class="button invite-button">
 			<span class="bp-screen-reader-text"><?php esc_html_e( 'Next', 'buddypress' );?></span>
 		</a>
 	<# } #>

--- a/bp-templates/bp-nouveau/buddypress/_accessoires/messages/index.php
+++ b/bp-templates/bp-nouveau/buddypress/_accessoires/messages/index.php
@@ -152,7 +152,7 @@
 						<dd>
 							<ul class="participants-list">
 								<# for ( i in data.recipients ) { #>
-									<li><a href="{{data.recipients[i].user_link}}" class="bp-tooltip" data-bp-tooltip="{{data.recipients[i].user_name}}"><img class="avatar mini" src="{{data.recipients[i].avatar}}" alt="{{data.recipients[i].user_name}}<?php esc_attr_e( ' profile picture', 'buddypress' ); ?>" /></a></li>
+									<li><a href="{{data.recipients[i].user_link}}"><img class="avatar mini" src="{{data.recipients[i].avatar}}" alt="{{data.recipients[i].user_name}}<?php esc_attr_e( ' profile picture', 'buddypress' ); ?>" /></a></li>
 								<# } #>
 							</ul>
 						</dd>
@@ -168,18 +168,18 @@
 					<# if ( undefined !== data.star_link ) { #>
 
 						<# if ( false !== data.is_starred ) { #>
-							<a role="button" class="message-action-unstar bp-tooltip bp-icons" href="{{data.star_link}}" data-bp-action="unstar" aria-pressed="true" data-bp-tooltip="<?php esc_attr_e( 'Unstar Conversation', 'buddypress' );?>">
+							<a role="button" class="message-action-unstar bp-icons" href="{{data.star_link}}" data-bp-action="unstar" aria-pressed="true">
 								<span class="bp-screen-reader-text"><?php esc_html_e( 'Unstar Conversation', 'buddypress' );?></span>
 							</a>
 						<# } else { #>
-							<a role="button" class="message-action-star bp-tooltip bp-icons" href="{{data.star_link}}" data-bp-action="star" aria-pressed="false" data-bp-tooltip="<?php esc_attr_e( 'Star Conversation', 'buddypress' );?>">
+							<a role="button" class="message-action-star bp-icons" href="{{data.star_link}}" data-bp-action="star" aria-pressed="false">
 								<span class="bp-screen-reader-text"><?php esc_html_e( 'Star Conversation', 'buddypress' );?></span>
 							</a>
 						<# } #>
 
 					<# } #>
 
-					<a href="#view/{{data.id}}" class="message-action-view bp-tooltip bp-icons" data-bp-tooltip="<?php esc_attr_e( 'View Full Conversation.', 'buddypress' );?>">
+					<a href="#view/{{data.id}}" class="message-action-view bp-icons">
 						<span class="bp-screen-reader-text"><?php esc_html_e( 'View Full conversation.', 'buddypress' );?></span>
 					</a>
 				</div>
@@ -201,7 +201,7 @@
 				<dd>
 					<ul class="participants-list">
 						<# for ( i in data.recipients ) { #>
-							<li><a href="{{data.recipients[i].user_link}}" class="bp-tooltip" data-bp-tooltip="{{data.recipients[i].user_name}}"><img class="avatar mini" src="{{data.recipients[i].avatar}}"  alt="{{data.recipients[i].user_name}}<?php esc_attr_e( ' profile picture', 'buddypress' ); ?>" /></a></li>
+							<li><a href="{{data.recipients[i].user_link}}"><img class="avatar mini" src="{{data.recipients[i].avatar}}"  alt="{{data.recipients[i].user_name}}<?php esc_attr_e( ' profile picture', 'buddypress' ); ?>" /></a></li>
 						<# } #>
 					</ul>
 				</dd>

--- a/bp-templates/bp-nouveau/buddypress/assets/_attachments/avatars/index.php
+++ b/bp-templates/bp-nouveau/buddypress/assets/_attachments/avatars/index.php
@@ -35,10 +35,10 @@ do_action( 'bp_attachments_avatar_check_template' );
 <script id="tmpl-bp-avatar-delete" type="text/html">
 	<# if ( 'user' === data.object ) { #>
 		<p><?php _e( "If you'd like to delete your current profile photo but not upload a new one, please use the delete profile photo button.", 'buddypress' ); ?></p>
-		<p><a class="button edit" id="bp-delete-avatar" href="#" title="<?php esc_attr_e( 'Delete Profile Photo', 'buddypress' ); ?>"><?php esc_html_e( 'Delete My Profile Photo', 'buddypress' ); ?></a></p>
+		<p><a class="button edit" id="bp-delete-avatar" href="#"><?php esc_html_e( 'Delete My Profile Photo', 'buddypress' ); ?></a></p>
 	<# } else if ( 'group' === data.object ) { #>
 		<?php bp_nouveau_user_feedback( 'group-avatar-delete-info' ); ?>
-		<p><a class="button edit" id="bp-delete-avatar" href="#" title="<?php esc_attr_e( 'Delete Group Profile Photo', 'buddypress' ); ?>"><?php esc_html_e( 'Delete Group Profile Photo', 'buddypress' ); ?></a></p>
+		<p><a class="button edit" id="bp-delete-avatar" href="#"><?php esc_html_e( 'Delete Group Profile Photo', 'buddypress' ); ?></a></p>
 	<# } else { #>
 		<?php do_action( 'bp_attachments_avatar_delete_template' ); ?>
 	<# } #>

--- a/bp-templates/bp-nouveau/buddypress/assets/_attachments/cover-images/index.php
+++ b/bp-templates/bp-nouveau/buddypress/assets/_attachments/cover-images/index.php
@@ -24,10 +24,10 @@
 <script id="tmpl-bp-cover-image-delete" type="text/html">
 	<# if ( 'user' === data.object ) { #>
 		<p><?php _e( "If you'd like to delete your current cover image but not upload a new one, please use the delete Cover Image button.", 'buddypress' ); ?></p>
-		<p><a class="button edit" id="bp-delete-cover-image" href="#" title="<?php esc_attr_e( 'Delete Cover Image', 'buddypress' ); ?>"><?php esc_html_e( 'Delete My Cover Image', 'buddypress' ); ?></a></p>
+		<p><a class="button edit" id="bp-delete-cover-image" href="#"><?php esc_html_e( 'Delete My Cover Image', 'buddypress' ); ?></a></p>
 	<# } else if ( 'group' === data.object ) { #>
 		<p><?php _e( "If you'd like to remove the existing group cover image but not upload a new one, please use the delete group cover image button.", 'buddypress' ); ?></p>
-		<p><a class="button edit" id="bp-delete-cover-image" href="#" title="<?php esc_attr_e( 'Delete Cover Image', 'buddypress' ); ?>"><?php esc_html_e( 'Delete Group Cover Image', 'buddypress' ); ?></a></p>
+		<p><a class="button edit" id="bp-delete-cover-image" href="#"><?php esc_html_e( 'Delete Group Cover Image', 'buddypress' ); ?></a></p>
 	<# } else { #>
 		<?php do_action( 'bp_attachments_cover_image_delete_template' ); ?>
 	<# } #>

--- a/bp-templates/bp-nouveau/buddypress/common/search-and-filters-bar.php
+++ b/bp-templates/bp-nouveau/buddypress/common/search-and-filters-bar.php
@@ -13,7 +13,7 @@
 	<div class="subnav-search clearfix">
 
 		<?php if ( 'activity' === bp_current_component() ) :?>
-			<div class="feed"><a href="<?php bp_sitewide_activity_feed_link(); ?>" class="bp-tooltip" data-bp-tooltip="<?php esc_attr_e( 'RSS Feed', 'buddypress' ); ?>"><span class="bp-screen-reader-text"><?php _e( 'RSS', 'buddypress' ); ?></span></a></div>
+			<div class="feed"><a href="<?php bp_sitewide_activity_feed_link(); ?>"><span class="bp-screen-reader-text"><?php _e( 'RSS', 'buddypress' ); ?></span></a></div>
 		<?php endif; ?>
 
 		<?php bp_nouveau_search_form(); ?>

--- a/bp-templates/bp-nouveau/buddypress/groups/single/activity.php
+++ b/bp-templates/bp-nouveau/buddypress/groups/single/activity.php
@@ -15,7 +15,7 @@
 	<div class="subnav-filters filters clearfix">
 
 		<ul>
-			<li class="feed"><a href="<?php bp_group_activity_feed_link(); ?>" class="bp-tooltip" data-bp-tooltip="<?php esc_attr_e( 'RSS Feed', 'buddypress' ); ?>" class="no-ajax"><span class="bp-screen-reader-text"><?php _e( 'RSS', 'buddypress' ); ?></span></a></li>
+			<li class="feed"><a href="<?php bp_group_activity_feed_link(); ?>" class="no-ajax"><span class="bp-screen-reader-text"><?php _e( 'RSS', 'buddypress' ); ?></span></a></li>
 
 			<li class="group-act-search"><?php bp_nouveau_search_form(); ?></li>
 		</ul>

--- a/bp-templates/bp-nouveau/buddypress/groups/single/cover-image-header.php
+++ b/bp-templates/bp-nouveau/buddypress/groups/single/cover-image-header.php
@@ -14,7 +14,7 @@
 	<div id="item-header-cover-image">
 		<?php if ( ! bp_disable_group_avatar_uploads() ) : ?>
 			<div id="item-header-avatar">
-				<a href="<?php echo esc_url( bp_get_group_permalink() ); ?>" title="<?php echo esc_attr( bp_get_group_name() ); ?>">
+				<a href="<?php echo esc_url( bp_get_group_permalink() ); ?>">
 
 					<?php bp_group_avatar(); ?>
 

--- a/bp-templates/bp-nouveau/buddypress/groups/single/group-header.php
+++ b/bp-templates/bp-nouveau/buddypress/groups/single/group-header.php
@@ -12,7 +12,7 @@
 
 <?php if ( ! bp_disable_group_avatar_uploads() ) : ?>
 	<div id="item-header-avatar">
-		<a href="<?php echo esc_url( bp_get_group_permalink() ); ?>" class="bp-tooltip" data-bp-title="<?php echo esc_attr( bp_get_group_name() ); ?>">
+		<a href="<?php echo esc_url( bp_get_group_permalink() ); ?>">
 
 			<?php bp_group_avatar(); ?>
 

--- a/bp-templates/bp-nouveau/buddypress/members/single/profile/change-avatar.php
+++ b/bp-templates/bp-nouveau/buddypress/members/single/profile/change-avatar.php
@@ -35,7 +35,7 @@
 
 			<?php if ( bp_get_user_has_avatar() ) : ?>
 				<p class="bp-help-text"><?php _e( "If you'd like to delete your current profile photo but not upload a new one, please use the delete profile photo button.", 'buddypress' ); ?></p>
-				<p><a class="button edit" href="<?php bp_avatar_delete_link(); ?>" title="<?php esc_attr_e( 'Delete Profile Photo', 'buddypress' ); ?>"><?php _e( 'Delete My Profile Photo', 'buddypress' ); ?></a></p>
+				<p><a class="button edit" href="<?php bp_avatar_delete_link(); ?>"><?php _e( 'Delete My Profile Photo', 'buddypress' ); ?></a></p>
 			<?php endif; ?>
 
 		<?php endif; ?>

--- a/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -52,7 +52,7 @@ function bp_nouveau_ajax_mark_activity_favorite() {
 
 			if ( 1 === $fav_count ) {
 				$response['directory_tab'] = '<li id="activity-favorites" data-bp-scope="favorites" data-bp-object="activity">
-					<a href="' . bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/" title="' . esc_attr__( "The activity I've marked as a favorite.", 'buddypress' ) . '">
+					<a href="' . bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/">
 						' . esc_html__( 'My Favorites', 'buddypress' ) . '
 					</a>
 				</li>';

--- a/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -496,6 +496,21 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 			}
 		}
 
+		// <a> elements should never have `title` attributes; see r11606.
+		foreach ( $buttons as &$button ) {
+			if ( 'a' !== $button['button_element'] ) {
+				continue;
+			}
+
+			if ( isset( $button['button_attr']['class'] ) ) {
+				$button['button_attr']['class'] = str_replace( 'bp-tooltip', '', $button['button_attr']['class'] );
+			}
+
+			if ( isset( $button['button_attr']['data-bp-tooltip'] ) ) {
+				unset( $button['button_attr']['data-bp-tooltip'] );
+			}
+		}
+
 		/**
 		 * Filter here to add your buttons, use the position argument to choose where to insert it.
 		 *

--- a/bp-templates/bp-nouveau/includes/members/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/members/template-tags.php
@@ -476,6 +476,21 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 			}
 		}
 
+		// <a> elements should never have `title` attributes; see r11606.
+		foreach ( $buttons as &$button ) {
+			if ( 'a' !== $button['button_element'] ) {
+				continue;
+			}
+
+			if ( isset( $button['button_attr']['class'] ) ) {
+				$button['button_attr']['class'] = str_replace( 'bp-tooltip', '', $button['button_attr']['class'] );
+			}
+
+			if ( isset( $button['button_attr']['data-bp-tooltip'] ) ) {
+				unset( $button['button_attr']['data-bp-tooltip'] );
+			}
+		}
+
 		/**
 		 * Filter here to add your buttons, use the position argument to choose where to insert it.
 		 *

--- a/bp-templates/bp-nouveau/includes/notifications/functions.php
+++ b/bp-templates/bp-nouveau/includes/notifications/functions.php
@@ -174,20 +174,18 @@ function bp_nouveau_notifications_sort( $filters = array() ) {
  * @since 1.0.0
  *
  * @param  string $link        The action link.
- * @param  string $bp_tooltip  The data-bp-attribute of the link.
  * @param  string $aria_label  The aria-label attribute of the link.
  * @param  string $dashicon    The dashicon class.
  * @return string              Link Output.
  */
-function bp_nouveau_notifications_dashiconified_link( $link = '', $bp_tooltip = '', $dashicon = '' ) {
+function bp_nouveau_notifications_dashiconified_link( $link = '', $dashicon = '' ) {
 	preg_match( '/<a\s[^>]*>(.*)<\/a>/siU', $link, $match );
 
 	if ( ! empty( $match[0] ) && ! empty( $match[1] ) && ! empty( $dashicon ) && ! empty( $bp_tooltip ) ) {
 		$link = str_replace(
 			'>' . $match[1] . '<',
 			sprintf(
-				' class="bp-tooltip" data-bp-tooltip="%1$s"><span class="dashicons %2$s" aria-hidden="true"></span><span class="bp-screen-reader-text">%3$s</span><',
-				esc_attr( $bp_tooltip ),
+				'><span class="dashicons %1$s" aria-hidden="true"></span><span class="bp-screen-reader-text">%2$s</span><',
 				sanitize_html_class( $dashicon ),
 				$match[1]
 			),
@@ -207,7 +205,7 @@ function bp_nouveau_notifications_dashiconified_link( $link = '', $bp_tooltip = 
  * @return string       Link Output.
  */
 function bp_nouveau_notifications_mark_unread_link( $link = '' ) {
-	return bp_nouveau_notifications_dashiconified_link( $link, __( 'Mark Unread', 'buddypress' ), 'dashicons-hidden' );
+	return bp_nouveau_notifications_dashiconified_link( $link, 'dashicons-hidden' );
 }
 
 /**
@@ -219,7 +217,7 @@ function bp_nouveau_notifications_mark_unread_link( $link = '' ) {
  * @return string       Link Output.
  */
 function bp_nouveau_notifications_mark_read_link( $link = '' ) {
-	return bp_nouveau_notifications_dashiconified_link( $link, __( 'Mark Read', 'buddypress' ), 'dashicons-visibility' );
+	return bp_nouveau_notifications_dashiconified_link( $link, 'dashicons-visibility' );
 }
 
 /**
@@ -231,5 +229,5 @@ function bp_nouveau_notifications_mark_read_link( $link = '' ) {
  * @return string       Link Output.
  */
 function bp_nouveau_notifications_delete_link( $link = '' ) {
-	return bp_nouveau_notifications_dashiconified_link( $link, __( 'Delete', 'buddypress' ), 'dashicons-dismiss' );
+	return bp_nouveau_notifications_dashiconified_link( $link, 'dashicons-dismiss' );
 }

--- a/bp-templates/bp-nouveau/includes/notifications/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/notifications/template-tags.php
@@ -87,8 +87,8 @@ function bp_nouveau_notifications_sort_order_links() {
 	?>
 
 	<span class="notifications-order-actions">
-		<a href="<?php echo esc_url( $desc ); ?>" class="bp-tooltip" data-bp-tooltip="<?php esc_attr_e( 'Newest First', 'buddypress' ); ?>" aria-label="<?php esc_attr_e( 'Newest First', 'buddypress' ); ?>" data-bp-notifications-order="DESC"><span class="dashicons dashicons-arrow-down"></span></a>
-		<a href="<?php echo esc_url( $asc ); ?>" class="bp-tooltip" data-bp-tooltip="<?php esc_attr_e( 'Older First', 'buddypress' ); ?>" aria-label="<?php esc_attr_e( 'Older First', 'buddypress' ); ?>" data-bp-notifications-order="ASC"><span class="dashicons dashicons-arrow-up" aria-hidden="true"></span></a>
+		<a href="<?php echo esc_url( $desc ); ?>" aria-label="<?php esc_attr_e( 'Newest First', 'buddypress' ); ?>" data-bp-notifications-order="DESC"><span class="dashicons dashicons-arrow-down"></span></a>
+		<a href="<?php echo esc_url( $asc ); ?>" aria-label="<?php esc_attr_e( 'Older First', 'buddypress' ); ?>" data-bp-notifications-order="ASC"><span class="dashicons dashicons-arrow-up" aria-hidden="true"></span></a>
 	</span>
 
 	<?php

--- a/bp-templates/bp-nouveau/js/buddypress-activity.js
+++ b/bp-templates/bp-nouveau/js/buddypress-activity.js
@@ -350,7 +350,7 @@ window.bp = window.bp || {};
 
 						// Prepend a link to display all
 						if ( ! i ) {
-							$( item ).before( '<li class="show-all"><a href="#' + activity_item.prop( 'id' ) + '/show-all/" aria-expanded="false" data-bp-tooltip="' + BP_Nouveau.show_all_comments + '">' + BP_Nouveau.show_x_comments.replace( '%d', comment_count ) + '</a></li>' );
+							$( item ).before( '<li class="show-all"><a href="#' + activity_item.prop( 'id' ) + '/show-all/" aria-expanded="false">' + BP_Nouveau.show_x_comments.replace( '%d', comment_count ) + '</a></li>' );
 						}
 					}
 				} );

--- a/bp-templates/bp-nouveau/testcases/activity/functions.php
+++ b/bp-templates/bp-nouveau/testcases/activity/functions.php
@@ -12,8 +12,8 @@ class BP_Nouveau_Activity_Functions extends Next_Template_Packs_TestCase {
 		$this->set_current_user( $this->user_id );
 
 		$this->hooked_nav = array(
-			'all_one' => sprintf( '<li id="activity-%1$s"><a href="%2$s" title="%3$s">%4$s</a></li>', 'foo', 'http://example.org/activity/foo', 'Foo', 'Foo' ),
-			'all_two' => sprintf( '<li id="activity-%1$s"><a href="%2$s" title="%3$s">%4$s <span>%5$s</span></a></li>', 'bar', 'http://example.org/activity/bar', 'Bar', 'Bar', 5 ),
+			'all_one' => sprintf( '<li id="activity-%1$s"><a href="%2$s">%3$s</a></li>', 'foo', 'http://example.org/activity/foo', 'Foo' ),
+			'all_two' => sprintf( '<li id="activity-%1$s"><a href="%2$s">%3$s <span>%4$s</span></a></li>', 'bar', 'http://example.org/activity/bar', 'Bar', 5 ),
 		);
 	}
 

--- a/bp-templates/bp-nouveau/testcases/blogs/functions.php
+++ b/bp-templates/bp-nouveau/testcases/blogs/functions.php
@@ -13,8 +13,8 @@ class BP_Nouveau_Blogs_Functions extends Next_Template_Packs_TestCase {
 		$this->set_current_user( $this->user_id );
 
 		$this->hooked_nav = array(
-			'all_one' => sprintf( '<li id="blogs-%1$s"><a href="%2$s" title="%3$s">%4$s</a></li>', 'foo', 'http://example.org/blogs/foo', 'Foo', 'Foo' ),
-			'all_two' => sprintf( '<li id="blogs-%1$s"><a href="%2$s" title="%3$s">%4$s <span>%5$s</span></a></li>', 'bar', 'http://example.org/blogs/bar', 'Bar', 'Bar', 5 ),
+			'all_one' => sprintf( '<li id="blogs-%1$s"><a href="%2$s">%3$s</a></li>', 'foo', 'http://example.org/blogs/foo', 'Foo' ),
+			'all_two' => sprintf( '<li id="blogs-%1$s"><a href="%2$s">%3$s <span>%4$s</span></a></li>', 'bar', 'http://example.org/blogs/bar', 'Bar', 5 ),
 		);
 	}
 

--- a/bp-templates/bp-nouveau/testcases/groups/functions.php
+++ b/bp-templates/bp-nouveau/testcases/groups/functions.php
@@ -22,7 +22,7 @@ class BP_Nouveau_Groups_Functions extends Next_Template_Packs_TestCase {
 	}
 
 	public function do_dir_nav() {
-		printf( '<li id="groups-%1$s"><a href="%2$s" title="%3$s">%4$s</a></li>', 'foo', 'http://example.org/groups/foo', 'Foo', 'Foo' );
+		printf( '<li id="groups-%1$s"><a href="%2$s">%3$s</a></li>', 'foo', 'http://example.org/groups/foo', 'Foo' );
 	}
 
 	public function filter_dir_nav( $nav_items ) {

--- a/bp-templates/bp-nouveau/testcases/members/functions.php
+++ b/bp-templates/bp-nouveau/testcases/members/functions.php
@@ -22,7 +22,7 @@ class BP_Nouveau_Members_Functions extends Next_Template_Packs_TestCase {
 	}
 
 	public function do_dir_nav() {
-		printf( '<li id="members-%1$s"><a href="%2$s" title="%3$s">%4$s</a></li>', 'foo', 'http://example.org/members/foo', 'Foo', 'Foo' );
+		printf( '<li id="members-%1$s"><a href="%2$s">%3$s</a></li>', 'foo', 'http://example.org/members/foo', 'Foo' );
 	}
 
 	public function filter_dir_nav( $nav_items ) {


### PR DESCRIPTION
I have not been familiar with the decision to implement the JS-powered tooltips, so I've only pulled those out on anchor elements where they appeared to be a direct replacement for the HTML `title=` attribute. I hope the accessibility has been reviewed.

In two of the giant button generating classes, I've added a block to conditionally unset them, given the `button_element` is dynamic.