### PR TITLE
Function escaping in template functions

### DIFF
--- a/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/bp-templates/bp-nouveau/buddypress-functions.php
@@ -589,13 +589,17 @@ class BP_Nouveau extends BP_Theme_Compat {
 	 * @return string
 	 */
 	public function theme_compat_wrapper( $retval ) {
-		// We already have a 'buddypress' wrapper, so bail.
 		if ( false !== strpos( $retval, '<div id="buddypress"' ) ) {
 			return $retval;
 		}
 
 		// Add our 'buddypress' div wrapper.
-		return sprintf( '<div id="buddypress" class="%1$s">%2$s</div><!-- #buddypress -->%3$s', bp_nouveau_get_buddypress_classes(), $retval, "\n" );
+		return sprintf(
+			'<div id="buddypress" class="%1$s">%2$s</div><!-- #buddypress -->%3$s',
+			esc_attr( bp_nouveau_get_container_classes() ),
+			$retval,  // Constructed HTML.
+			"\n"
+		);
 	}
 
 	/**

--- a/bp-templates/bp-nouveau/buddypress/common/nav/directory-nav.php
+++ b/bp-templates/bp-nouveau/buddypress/common/nav/directory-nav.php
@@ -16,7 +16,7 @@
 
 			<?php while ( bp_nouveau_nav_items() ) : bp_nouveau_nav_item(); ?>
 
-				<li id="<?php bp_nouveau_nav_id(); ?>" class="<?php bp_nouveau_nav_classes(); ?>"<?php bp_nouveau_nav_scope(); ?> data-bp-object="<?php bp_nouveau_directory_nav_object(); ?>">
+				<li id="<?php bp_nouveau_nav_id(); ?>" class="<?php bp_nouveau_nav_classes(); ?>" <?php bp_nouveau_nav_scope(); ?> data-bp-object="<?php bp_nouveau_directory_nav_object(); ?>">
 					<a href="<?php bp_nouveau_nav_link(); ?>">
 						<?php bp_nouveau_nav_link_text(); ?>
 

--- a/bp-templates/bp-nouveau/buddypress/members/single/parts/item-subnav.php
+++ b/bp-templates/bp-nouveau/buddypress/members/single/parts/item-subnav.php
@@ -12,7 +12,7 @@
 
 	<?php while ( bp_nouveau_nav_items() ) : bp_nouveau_nav_item(); ?>
 
-		<li id="<?php bp_nouveau_nav_id(); ?>" class="<?php bp_nouveau_nav_classes(); ?>"<?php bp_nouveau_nav_scope(); ?>>
+		<li id="<?php bp_nouveau_nav_id(); ?>" class="<?php bp_nouveau_nav_classes(); ?>" <?php bp_nouveau_nav_scope(); ?>>
 			<a href="<?php bp_nouveau_nav_link(); ?>" id="<?php bp_nouveau_nav_link_id(); ?>">
 				<?php bp_nouveau_nav_link_text(); ?>
 

--- a/bp-templates/bp-nouveau/includes/activity/functions.php
+++ b/bp-templates/bp-nouveau/includes/activity/functions.php
@@ -92,7 +92,7 @@ function bp_nouveau_activity_localize_scripts( $params = array() ) {
 	}
 
 	/**
-	 * Filter here to include specific Action buttons.
+	 * Filter to include specific Action buttons.
 	 *
 	 * @since 1.0.0
 	 *
@@ -464,7 +464,7 @@ function bp_nouveau_activity_widget_query() {
 	}
 
 	/**
-	 * Filter here to edit the activity widget arguments
+	 * Filter to edit the activity widget arguments
 	 *
 	 * @since 1.0.0
 	 *

--- a/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -519,7 +519,7 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 		}
 
 		// It's the first entry of the loop, so build the Group and sort it
-		if ( ! isset( bp_nouveau()->activity->entry_buttons ) || false === is_a( bp_nouveau()->activity->entry_buttons, 'BP_Buttons_Group' ) ) {
+		if ( ! isset( bp_nouveau()->activity->entry_buttons ) || ! is_a( bp_nouveau()->activity->entry_buttons, 'BP_Buttons_Group' ) ) {
 			$sort = true;
 			bp_nouveau()->activity->entry_buttons = new BP_Buttons_Group( $buttons_group );
 

--- a/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -76,6 +76,11 @@ function bp_nouveau_before_activity_post_form() {
 		wp_enqueue_script( 'bp-nouveau-activity-post-form' );
 	}
 
+	/**
+	 * Fires before the activity post form.
+	 *
+	 * @since 1.2.0
+	 */
 	do_action( 'bp_before_activity_post_form' );
 }
 
@@ -89,6 +94,11 @@ function bp_nouveau_after_activity_post_form() {
 		bp_get_template_part( '_accessoires/activity/form' );
 	}
 
+	/**
+	 * Fires after the activity post form.
+	 *
+	 * @since 1.2.0
+	 */
 	do_action( 'bp_after_activity_post_form' );
 }
 
@@ -97,7 +107,7 @@ function bp_nouveau_after_activity_post_form() {
  *
  * @since 1.0.0
  *
- * @return string HTML Outpur
+ * @return string HTML.
  */
 function bp_nouveau_activity_member_post_form() {
 
@@ -131,20 +141,17 @@ function bp_nouveau_activity_member_post_form() {
 function bp_nouveau_activity_hook( $when = '', $suffix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( ! $when ) {
 		$hook[] = $when;
 	}
 
 	// It's a activity entry hook
 	$hook[] = 'activity';
 
-	if ( ! empty( $suffix ) ) {
+	if ( ! $suffix ) {
 		$hook[] = $suffix;
 	}
 
-	/**
-	 * @since 1.2.0 (BuddyPress)
-	 */
 	bp_nouveau_hook( $hook );
 }
 
@@ -178,12 +185,11 @@ function bp_nouveau_activity_content() {
 }
 
 /**
- * Output the action buttons inside an Activity Loop
+ * Output the action buttons inside an Activity Loop.
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_activity_entry_buttons( $args = array() ) {
 	$output = join( ' ', bp_nouveau_get_activity_entry_buttons( $args ) );
@@ -200,21 +206,21 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 	$output .= ob_get_clean();
 
 	$has_content = trim( $output, ' ' );
-
-	if ( empty( $has_content ) ) {
+	if ( ! $has_content ) {
 		return;
 	}
 
-	if ( empty( $args ) ) {
+	if ( ! $args ) {
 		$args = array( 'classes' => array( 'activity-meta' ) );
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 	/**
-	 * Get the action buttons inside an Activity Loop
+	 * Get the action buttons inside an Activity Loop,
 	 *
+	 * @todo This function is too large and needs refactoring and reviewing.
 	 * @since 1.0.0
 	 */
 	function bp_nouveau_get_activity_entry_buttons( $args ) {
@@ -224,28 +230,28 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 			return $buttons;
 		}
 
-		$activity_id   = bp_get_activity_id();
-		$activity_type = bp_get_activity_type();
+		$activity_id    = bp_get_activity_id();
+		$activity_type  = bp_get_activity_type();
+		$parent_element = '';
+		$button_element = 'a';
 
-		if ( empty( $activity_id ) ) {
+		if ( ! $activity_id ) {
 			return $buttons;
 		}
 
-		/**
-		* If the container is set to 'ul'
-		* force the $parent_element to 'li', else use
-		* parent_element args if set.
-		* Will render li elements around anchors/buttons.
-		*/
+		/*
+		 * If the container is set to 'ul' force the $parent_element to 'li',
+		 * else use parent_element args if set.
+		 *
+		 * Will render li elements around anchors/buttons.
+		 */
 		if ( 'ul' === $args['container']  ) {
 			$parent_element = 'li';
 		} elseif ( ! empty( $args['parent_element'] ) ) {
-			$parent_element = esc_html( $args['parent_element'] );
-		} else {
-			$parent_element = false;
+			$parent_element = $args['parent_element'];
 		}
 
-		$parent_attr = ( ! empty( $args['parent_attr'] ) )? $args['parent_attr']  : '';
+		$parent_attr = ( ! empty( $args['parent_attr'] ) ) ? $args['parent_attr']  : '';
 
 		/*
 		 * If we have a arg value for $button_element passed through
@@ -254,14 +260,11 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 		 * Or override & hardcode the 'element' string on $buttons array.
 		 *
 		 */
-
 		if ( ! empty( $args['button_element'] ) ) {
-			$button_element = $args['button_element'] ;
-		} else {
-			$button_element = 'a';
+			$button_element = $args['button_element'];
 		}
 
-		/**
+		/*
 		 * The view conversation button and the comment one are sharing
 		 * the same id because when display_comments is on stream mode,
 		 * it is not possible to comment an activity comment and as we
@@ -270,7 +273,7 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 		 * sure the right button will be displayed.
 		 */
 		if ( $activity_type === 'activity_comment' ) {
-			$buttons['activity_conversation'] =  array(
+			$buttons['activity_conversation'] = array(
 				'id'                => 'activity_conversation',
 				'position'          => 5,
 				'component'         => 'activity',
@@ -282,117 +285,119 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 					'class'           => 'button view bp-secondary-action bp-tooltip',
 					'data-bp-tooltip' => __( 'View Conversation', 'buddypress' ),
 					),
-				'link_text'  => sprintf( '<span class="bp-screen-reader-text">%1$s</span>',esc_html__( 'View Conversation', 'buddypress' ) ),
+				'link_text' => sprintf(
+					'<span class="bp-screen-reader-text">%1$s</span>',
+					esc_html__( 'View Conversation', 'buddypress' )
+				),
 			);
 
 			// If button element set add url link to data-attr
 			if ( 'button' === $button_element ) {
-				$buttons['activity_conversation']['button_attr']['data-bp-url'] = esc_url( bp_get_activity_thread_permalink() );
+				$buttons['activity_conversation']['button_attr']['data-bp-url'] = bp_get_activity_thread_permalink();
 			} else {
-				$buttons['activity_conversation']['button_attr']['href'] = esc_url( bp_get_activity_thread_permalink() );
+				$buttons['activity_conversation']['button_attr']['href'] = bp_get_activity_thread_permalink();
 				$buttons['activity_conversation']['button_attr']['role'] = 'button';
 			}
 
-		/**
-		 * We always create the Button to make sure
-		 * we always have the right numbers of buttons
-		 * no matter the previous activity had less
+		/*
+		 * We always create the Button to make sure we always have the right numbers of buttons,
+		 * no matter the previous activity had less.
 		 */
 		} else {
 			$buttons['activity_conversation'] =  array(
-				'id'                  => 'activity_conversation',
-				'position'            => 5,
-				'component'           => 'activity',
-				'parent_element'      => $parent_element,
-				'parent_attr'         => $parent_attr,
-				'must_be_logged_in'   => true,
-				'button_element'      => $button_element,
-				'button_attr'         => array(
+				'id'                => 'activity_conversation',
+				'position'          => 5,
+				'component'         => 'activity',
+				'parent_element'    => $parent_element,
+				'parent_attr'       => $parent_attr,
+				'must_be_logged_in' => true,
+				'button_element'    => $button_element,
+				'button_attr'       => array(
 					'id'              => 'acomment-comment-' . $activity_id,
 					'class'           => 'button acomment-reply bp-primary-action bp-tooltip',
 					'data-bp-tooltip' => __( 'Comment', 'buddypress' ),
-					'aria-expanded'   => 'false'
-					),
-				'link_text'  => sprintf( '<span class="bp-screen-reader-text">%1$s</span> <span class="comment-count">%2$s</span>', esc_html__( 'Comment', 'buddypress' ), bp_activity_get_comment_count() ),
+					'aria-expanded'   => 'false',
+				),
+				'link_text'  => sprintf(
+					'<span class="bp-screen-reader-text">%1$s</span> <span class="comment-count">%2$s</span>',
+					esc_html__( 'Comment', 'buddypress' ),
+					esc_html( bp_activity_get_comment_count() )
+				),
 			);
 
 			// If button element set add href link to data-attr
 			if ( 'button' === $button_element ) {
-				$buttons['activity_conversation']['button_attr']['data-bp-url'] = esc_url( bp_get_activity_comment_link() );
+				$buttons['activity_conversation']['button_attr']['data-bp-url'] = bp_get_activity_comment_link();
 			} else {
-				$buttons['activity_conversation']['button_attr']['href'] = esc_url( bp_get_activity_comment_link() );
+				$buttons['activity_conversation']['button_attr']['href'] = bp_get_activity_comment_link();
 				$buttons['activity_conversation']['button_attr']['role'] = 'button';
 			}
 
 		}
 
 		if ( bp_activity_can_favorite() ) {
-
 			if ( ! bp_get_activity_is_favorite() ) {
-
 				$fav_args = array(
 					'parent_element'   => $parent_element,
 					'parent_attr'      => $parent_attr,
 					'button_element'   => $button_element,
 					'link_class'       => 'button fav bp-secondary-action bp-tooltip',
-					'data_bp_tooltip'  => esc_attr__( 'Mark as Favorite', 'buddypress' ),
+					'data_bp_tooltip'  => __( 'Mark as Favorite', 'buddypress' ),
 					'link_text'        => __( 'Favorite', 'buddypress' ),
-					'aria-pressed'     => 'false'
+					'aria-pressed'     => 'false',
 				);
 
 				// If button element set add nonce link to data-attr attr
 				if ( 'button' === $button_element ) {
-					$fav_args['data_attr'] = esc_url( bp_get_activity_favorite_link() );
+					$fav_args['data_attr'] = bp_get_activity_favorite_link();
 					$key = 'data-bp-nonce';
 				} else {
-					$fav_args['link_href'] = esc_url( bp_get_activity_favorite_link() );
+					$fav_args['link_href'] = bp_get_activity_favorite_link();
 				}
 
 			} else {
-
 				$fav_args = array(
-					'parent_element'   => $parent_element,
-					'parent_attr'      => $parent_attr,
-					'button_element'   => $button_element,
-					'link_class'       => 'button unfav bp-secondary-action bp-tooltip',
-					'data_bp_tooltip'  => esc_attr__( 'Remove Favorite', 'buddypress' ),
-					'link_text'        => __( 'Remove Favorite', 'buddypress' ),
-					'aria-pressed'     => 'true'
+					'parent_element'  => $parent_element,
+					'parent_attr'     => $parent_attr,
+					'button_element'  => $button_element,
+					'link_class'      => 'button unfav bp-secondary-action bp-tooltip',
+					'data_bp_tooltip' => __( 'Remove Favorite', 'buddypress' ),
+					'link_text'       => __( 'Remove Favorite', 'buddypress' ),
+					'aria-pressed'    => 'true',
 				);
 
 				// If button element set add nonce link nonce to data-attr
 				if ( 'button' === $button_element ) {
-					$fav_args['data_attr'] = esc_url(bp_get_activity_unfavorite_link() );
+					$fav_args['data_attr'] = bp_get_activity_unfavorite_link();
 					$key = 'data-bp-nonce';
 				} else {
-					$fav_args['link_href'] = esc_url( bp_get_activity_unfavorite_link() );
+					$fav_args['link_href'] = bp_get_activity_unfavorite_link();
 				}
-
 			}
 
 			$buttons['activity_favorite'] =  array(
-				'id'                  => 'activity_favorite',
-				'position'            => 15,
-				'component'           => 'activity',
-				'parent_element'      => $parent_element,
-				'parent_attr'         => $parent_attr,
-				'must_be_logged_in'   => true,
-				'button_element'      => $fav_args['button_element'],
-				'button_attr'         => array(
+				'id'                => 'activity_favorite',
+				'position'          => 15,
+				'component'         => 'activity',
+				'parent_element'    => $parent_element,
+				'parent_attr'       => $parent_attr,
+				'must_be_logged_in' => true,
+				'button_element'    => $fav_args['button_element'],
+				'link_text'         => sprintf( '<span class="bp-screen-reader-text">%1$s</span>', esc_html( $fav_args['link_text'] ) ),
+				'button_attr'       => array(
 					'href'            => $fav_args['link_href'],
 					'class'           => $fav_args['link_class'],
-					'data-bp-tooltip' => esc_attr( $fav_args['data_bp_tooltip'] ),
+					'data-bp-tooltip' => $fav_args['data_bp_tooltip'],
 					'aria-pressed'    => $fav_args['aria-pressed'],
 					$key              => $fav_args['data_attr'],
-					),
-				'link_text'   => sprintf( '<span class="bp-screen-reader-text">%1$s</span>', esc_html( $fav_args['link_text'] ) ),
+				),
 			);
 		}
 
 		// The delete button is always created, and removed later on if needed.
 		$delete_args = array();
 
-		/**
+		/*
 		 * As the delete link is filterable we need this workaround
 		 * to try to intercept the edits the filter made and build
 		 * a button out of it.
@@ -414,36 +419,34 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 			}
 
 			$delete_args = wp_parse_args( $delete_args, array(
-				'button_attr'         => array(
+				'link_text'   => '',
+				'button_attr' => array(
 					'link_id'         => '',
 					'link_href'       => '',
 					'link_class'      => '',
 					'link_rel'        => 'nofollow',
 					'data_bp_tooltip' => '',
-					),
-				'link_text'  => '',
+				),
 			) );
 		}
 
 		if ( empty( $delete_args['link_href'] ) ) {
-			$delete_args[] = bp_get_activity_delete_url();
-			$class = 'delete-activity';
-
 			$delete_args = array(
-				'button_element'    => $button_element,
-				'link_id'           => '',
-				'link_class'        => 'button item-button bp-secondary-action bp-tooltip ' . $class . ' confirm',
-				'link_rel'          => 'nofollow',
-				'data_bp_tooltip'        => esc_attr__( 'Delete', 'buddypress' ),
-				'link_text'         => __( 'Delete', 'buddypress' ),
+				'button_element'  => $button_element,
+				'link_id'         => '',
+				'link_class'      => 'button item-button bp-secondary-action bp-tooltip delete-activity confirm',
+				'link_rel'        => 'nofollow',
+				'data_bp_tooltip' => __( 'Delete', 'buddypress' ),
+				'link_text'       => __( 'Delete', 'buddypress' ),
+				'link_href'       => bp_get_activity_delete_url(),
 			);
 
 			// If button element set add nonce link to data-attr attr
 			if ( 'button' === $button_element ) {
-				$delete_args['data-attr'] = esc_url( bp_get_activity_delete_url() );
+				$delete_args['data-attr'] = bp_get_activity_delete_url();
 				$delete_args['link_href'] = '';
 			} else {
-				$delete_args['link_href'] = esc_url( bp_get_activity_delete_url() );
+				$delete_args['link_href'] = bp_get_activity_delete_url();
 				$delete_args['data-attr'] = '';
 			}
 		}
@@ -457,12 +460,12 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 			'must_be_logged_in' => true,
 			'button_element'    => $button_element,
 			'button_attr'       => array(
-				'id'              => esc_attr( $delete_args['link_id'] ),
+				'id'              => $delete_args['link_id'],
 				'href'            => $delete_args['link_href'],
 				'class'           => $delete_args['link_class'],
-				'data-bp-tooltip' => esc_attr( $delete_args['data_bp_tooltip'] ),
+				'data-bp-tooltip' => $delete_args['data_bp_tooltip'],
 				'data-bp-nonce'   => $delete_args['data-attr'] ,
-				),
+			),
 			'link_text'  => sprintf( '<span class="bp-screen-reader-text">%s</span>', esc_html( $delete_args['data_bp_tooltip'] ) ),
 		);
 
@@ -479,7 +482,7 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 				'button_attr'       => array(
 					'class'           => 'bp-secondary-action spam-activity confirm button item-button bp-tooltip',
 					'id'              =>  'activity_make_spam_' . $activity_id,
-					'data-bp-tooltip' =>  esc_attr__( 'Spam', 'buddypress' ),
+					'data-bp-tooltip' =>  __( 'Spam', 'buddypress' ),
 					),
 				'link_text'  => sprintf(
 					/** @todo: use a specific css rule for this *************************************************************/
@@ -488,16 +491,21 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 				),
 			);
 
-			// If button element set add nonce link to data-attr attr
+			// If button element, add nonce link to data attribute.
 			if ( 'button' === $button_element ) {
-				$buttons['activity_spam']['button_attr']['data-bp-nonce'] =  wp_nonce_url( bp_get_root_domain() . '/' . bp_get_activity_slug() . '/spam/' . $activity_id . '/', 'bp_activity_akismet_spam_' . $activity_id );
+				$data_element = 'data-bp-nonce';
 			} else {
-				$buttons['activity_spam']['button_attr']['href'] =  wp_nonce_url( bp_get_root_domain() . '/' . bp_get_activity_slug() . '/spam/' . $activity_id . '/', 'bp_activity_akismet_spam_' . $activity_id );
+				$data_element = 'href';
 			}
+
+			$buttons['activity_spam']['button_attr'][ $data_element ] = wp_nonce_url(
+				bp_get_root_domain() . '/' . bp_get_activity_slug() . '/spam/' . $activity_id . '/',
+				'bp_activity_akismet_spam_' . $activity_id
+			);
 		}
 
 		/**
-		 * Filter here to add your buttons, use the position argument to choose where to insert it.
+		 * Filter to add your buttons, use the position argument to choose where to insert it.
 		 *
 		 * @since 1.0.0
 		 *
@@ -506,7 +514,7 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 		 */
 		$buttons_group = apply_filters( 'bp_nouveau_get_activity_entry_buttons', $buttons, $activity_id );
 
-		if ( empty( $buttons_group ) ) {
+		if ( ! $buttons_group ) {
 			return $buttons;
 		}
 
@@ -563,7 +571,7 @@ function bp_nouveau_activity_comments() {
 	global $activities_template;
 
 	if ( empty( $activities_template->activity->children ) ) {
-		return false;
+		return;
 	}
 
 	bp_nouveau_activity_recurse_comments( $activities_template->activity );
@@ -579,17 +587,12 @@ function bp_nouveau_activity_comments() {
  * @global object $activities_template {@link BP_Activity_Template}
  *
  * @param object $comment The activity object currently being recursed.
- * @return bool|string
  */
 function bp_nouveau_activity_recurse_comments( $comment ) {
 	global $activities_template;
 
-	if ( empty( $comment ) ) {
-		return false;
-	}
-
 	if ( empty( $comment->children ) ) {
-		return false;
+		return;
 	}
 
 	/**
@@ -652,7 +655,7 @@ function bp_nouveau_activity_comment_action() {
 	function bp_nouveau_get_activity_comment_action() {
 
 		/**
-		 * Filter here to edit the activity comment action.
+		 * Filter to edit the activity comment action.
 		 *
 		 * @since 1.0.0
 		 *
@@ -691,11 +694,10 @@ function bp_nouveau_activity_comment_form() {
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_activity_comment_buttons( $args = array() ) {
-	$output = join( ' ', bp_nouveau_get_activity_comment_buttons($args) );
+	$output = join( ' ', bp_nouveau_get_activity_comment_buttons( $args ) );
 
 	ob_start();
 	/**
@@ -704,25 +706,28 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 	 * @since 1.6.0 (BuddyPress)
 	 */
 	do_action( 'bp_activity_comment_options' );
+
 	$output .= ob_get_clean();
-
 	$has_content = trim( $output, ' ' );
-
-	if ( empty( $has_content ) ) {
+	if ( ! $has_content ) {
 		return;
 	}
 
-	if ( empty( $args ) ) {
+	if ( ! $args ) {
 		$args = array( 'classes' => array( 'acomment-options' ) );
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 	/**
 	 * Get the action buttons for the activity comments
 	 *
 	 * @since 1.0.0
+	 *
+	 * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.
+	 *
+	 * @return array
 	 */
 	function bp_nouveau_get_activity_comment_buttons($args) {
 		$buttons = array();
@@ -731,10 +736,10 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 			return $buttons;
 		}
 
-		$activity_comment_id = (int) bp_get_activity_comment_id();
-		$activity_id         = (int) bp_get_activity_id();
+		$activity_comment_id = bp_get_activity_comment_id();
+		$activity_id         = bp_get_activity_id();
 
-		if ( empty( $activity_comment_id ) || empty( $activity_id ) ) {
+		if ( ! $activity_comment_id || ! $activity_id ) {
 			return $buttons;
 		}
 
@@ -747,7 +752,7 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 		if ( 'ul' === $args['container']  ) {
 			$parent_element = 'li';
 		} elseif ( ! empty( $args['parent_element'] ) ) {
-			$parent_element = esc_html( $args['parent_element'] );
+			$parent_element = $args['parent_element'];
 		} else {
 			$parent_element = false;
 		}
@@ -759,13 +764,14 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 		 * use it to default all the $buttons['button_element'] values
 		 * otherwise default to 'a' (anchor).
 		 */
-		if ( !empty( $args['button_element'] ) ) {
+		if ( ! empty( $args['button_element'] ) ) {
 			$button_element = $args['button_element'] ;
 		} else {
 			$button_element = 'a';
 		}
 
-		$buttons = array( 'activity_comment_reply' => array(
+		$buttons = array(
+			'activity_comment_reply' => array(
 				'id'                => 'activity_comment_reply',
 				'position'          => 5,
 				'component'         => 'activity',
@@ -773,11 +779,11 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 				'parent_element'    => $parent_element,
 				'parent_attr'       => $parent_attr,
 				'button_element'    => $button_element,
+				'link_text'         => __( 'Reply', 'buddypress' ),
 				'button_attr'       =>  array(
-					'class'  => 'acomment-reply bp-primary-action' . $icons . '',
-					'id'     => sprintf( 'acomment-reply-%1$s-from-%2$s', $activity_id, $activity_comment_id ),
+					'class' => "acomment-reply bp-primary-action {$icons}",
+					'id'    => sprintf( 'acomment-reply-%1$s-from-%2$s', $activity_id, $activity_comment_id ),
 				),
-				'link_text'         => esc_html__( 'Reply', 'buddypress' ),
 			),
 			'activity_comment_delete' => array(
 				'id'                => 'activity_comment_delete',
@@ -787,21 +793,21 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 				'parent_element'    => $parent_element,
 				'parent_attr'       => $parent_attr,
 				'button_element'    => $button_element,
+				'link_text'         => __( 'Delete', 'buddypress' ),
 				'button_attr'       => array(
-					'class'  => 'delete acomment-delete confirm bp-secondary-action',
-					'rel'    => 'nofollow',
+					'class' => 'delete acomment-delete confirm bp-secondary-action',
+					'rel'   => 'nofollow',
 					),
-				'link_text'         => esc_html__( 'Delete', 'buddypress' ),
 			),
 		);
 
 			// If button element set add nonce link to data-attr attr
 			if ( 'button' === $button_element ) {
 				$buttons['activity_comment_reply']['button_attr']['data-bp-act-reply-nonce'] = sprintf( '#acomment-%s', $activity_comment_id );
-				$buttons['activity_comment_delete']['button_attr']['data-bp-act-reply-delete-nonce'] = esc_url( bp_get_activity_comment_delete_link() );
+				$buttons['activity_comment_delete']['button_attr']['data-bp-act-reply-delete-nonce'] = bp_get_activity_comment_delete_link();
 			} else {
 				$buttons['activity_comment_reply']['button_attr']['href'] = sprintf( '#acomment-%s', $activity_comment_id );
-				$buttons['activity_comment_delete']['button_attr']['href'] = esc_url( bp_get_activity_comment_delete_link() );
+				$buttons['activity_comment_delete']['button_attr']['href'] = bp_get_activity_comment_delete_link();
 			}
 
 		// Add the Spam Button if supported
@@ -814,24 +820,29 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 				'parent_element'    => $parent_element,
 				'parent_attr'       => $parent_attr,
 				'button_element'    => $button_element,
-				'button_attr'       =>  array(
-					'id'     => 'activity_make_spam_' . $activity_comment_id,
+				'link_text'         => __( 'Spam', 'buddypress' ),
+				'button_attr'       => array(
+					'id'     => "activity_make_spam_{$activity_comment_id}",
 					'class'  => 'bp-secondary-action spam-activity-comment confirm',
 					'rel'    => 'nofollow',
 				),
-				'link_text'          => esc_html__( 'Spam', 'buddypress' ),
 			);
 
 			// If button element set add nonce link to data-attr attr
 			if ( 'button' === $button_element ) {
-				$buttons['activity_comment_spam']['button_attr']['data-bp-act-spam-nonce'] =  wp_nonce_url( bp_get_root_domain() . '/' . bp_get_activity_slug() . '/spam/' . $activity_comment_id . '/?cid=' . $activity_comment_id, 'bp_activity_akismet_spam_' . $activity_comment_id );
+				$data_element = 'data-bp-act-spam-nonce';
 			} else {
-				$buttons['activity_comment_spam']['button_attr']['href'] =  wp_nonce_url( bp_get_root_domain() . '/' . bp_get_activity_slug() . '/spam/' . $activity_comment_id . '/?cid=' . $activity_comment_id, 'bp_activity_akismet_spam_' . $activity_comment_id );
+				$data_element = 'href';
 			}
+
+			$buttons['activity_comment_spam']['button_attr'][ $data_element ] = wp_nonce_url(
+				bp_get_root_domain() . '/' . bp_get_activity_slug() . '/spam/' . $activity_comment_id . '/?cid=' . $activity_comment_id,
+				'bp_activity_akismet_spam_' . $activity_comment_id
+			);
 		}
 
 		/**
-		 * Filter here to add your buttons, use the position argument to choose where to insert it.
+		 * Filter to add your buttons, use the position argument to choose where to insert it.
 		 *
 		 * @since 1.0.0
 		 *
@@ -841,12 +852,12 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 		 */
 		$buttons_group = apply_filters( 'bp_nouveau_get_activity_comment_buttons', $buttons, $activity_comment_id, $activity_id );
 
-		if ( empty( $buttons_group ) ) {
+		if ( ! $buttons_group ) {
 			return $buttons;
 		}
 
 		// It's the first comment of the loop, so build the Group and sort it
-		if ( ! isset( bp_nouveau()->activity->comment_buttons ) || false === is_a( bp_nouveau()->activity->comment_buttons, 'BP_Buttons_Group' ) ) {
+		if ( ! isset( bp_nouveau()->activity->comment_buttons ) || ! is_a( bp_nouveau()->activity->comment_buttons, 'BP_Buttons_Group' ) ) {
 			$sort = true;
 			bp_nouveau()->activity->comment_buttons = new BP_Buttons_Group( $buttons_group );
 
@@ -878,7 +889,7 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 			unset( $return['activity_comment_delete'] );
 		}
 
-		if ( isset( $return['activity_comment_spam'] ) && ( ! bp_activity_current_comment() || ! in_array( bp_activity_current_comment()->type, BP_Akismet::get_activity_types() ) ) ) {
+		if ( isset( $return['activity_comment_spam'] ) && ( ! bp_activity_current_comment() || ! in_array( bp_activity_current_comment()->type, BP_Akismet::get_activity_types(), true ) ) ) {
 			unset( $return['activity_comment_spam'] );
 		}
 

--- a/bp-templates/bp-nouveau/includes/blogs/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/blogs/template-tags.php
@@ -230,7 +230,7 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 			// If we pass through parent classes add them to $button array
 			$parent_class = '';
 			if ( ! empty( $args['parent_attr']['class'] ) ) {
-				$parent_class = esc_html( $args['parent_attr']['class'] );
+				$parent_class = $args['parent_attr']['class'];
 			}
 
 			$buttons['visit_blog'] = array(
@@ -274,7 +274,7 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 		}
 
 		// It's the first entry of the loop, so build the Group and sort it
-		if ( ! isset( bp_nouveau()->blogs->group_buttons ) || false === is_a( bp_nouveau()->blogs->group_buttons, 'BP_Buttons_Group' ) ) {
+		if ( ! isset( bp_nouveau()->blogs->group_buttons ) || ! is_a( bp_nouveau()->blogs->group_buttons, 'BP_Buttons_Group' ) ) {
 			$sort = true;
 			bp_nouveau()->blogs->group_buttons = new BP_Buttons_Group( $buttons_group );
 

--- a/bp-templates/bp-nouveau/includes/blogs/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/blogs/template-tags.php
@@ -86,28 +86,26 @@ function bp_nouveau_after_blogs_directory_content() {
  * Fire specific hooks into the blogs create template
  *
  * @since 1.0.0
+ * @since 1.1.0 (BuddyPress) for the 'content' suffix
+ * @since 1.6.0 (BuddyPress) for the 'content_template' suffix
  *
- * @param string $when    'before' or 'after'
- * @param string $suffix  Use it to add terms at the end of the hook name
+ * @param string $when   Either 'before' or 'after'.
+ * @param string $suffix Use it to add terms at the end of the hook name.
  */
 function bp_nouveau_blogs_create_hook( $when = '', $suffix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( $when ) {
 		$hook[] = $when;
 	}
 
 	// It's a create a blog hook
 	$hook[] = 'create_blog';
 
-	if ( ! empty( $suffix ) ) {
+	if ( $suffix ) {
 		$hook[] = $suffix;
 	}
 
-	/**
-	 * @since 1.1.0 (BuddyPress) for the 'content' suffix
-	 * @since 1.6.0 (BuddyPress) for the 'content_template' suffix
-	 */
 	bp_nouveau_hook( $hook );
 }
 
@@ -130,12 +128,11 @@ function bp_nouveau_blogs_loop_item() {
  *
  * @since 1.0.0
  *
- * @param array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 	if ( empty( $GLOBALS['blogs_template'] ) ) {
-		return '';
+		return;
 	}
 
 	$args['type'] = 'loop';
@@ -151,11 +148,11 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 	do_action( 'bp_directory_blogs_actions' );
 	$output .= ob_get_clean();
 
-	if ( empty( $output ) ) {
-		return '';
+	if ( ! $output ) {
+		return;
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 	/**
@@ -169,7 +166,7 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 	function bp_nouveau_get_blogs_buttons( $args ) {
 		$type = ( ! empty( $args['type'] ) ) ? $args['type'] : 'loop';
 
-		// Not really sure why BP Legacy needed to do this...
+		// @todo Not really sure why BP Legacy needed to do this...
 		if ( 'loop' !== $type && is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			return array();
 		}
@@ -190,14 +187,13 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 		 * otherwise simply pass any value found in args
 		 * or set var false.
 		 */
-		if ( ! empty( $args['container'] ) && 'ul' === $args['container']  ) {
+		if ( ! empty( $args['container'] ) && 'ul' === $args['container'] ) {
 			$parent_element = 'li';
 		} elseif ( ! empty( $args['parent_element'] ) ) {
-			$parent_element = esc_html( $args['parent_element'] );
+			$parent_element = $args['parent_element'];
 		} else {
 			$parent_element = false;
 		}
-
 
 		/*
 		 * If we have a arg value for $button_element passed through
@@ -231,11 +227,11 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 		if ( ! empty( bp_nouveau()->blogs->button_args ) ) {
 			$button_args = bp_nouveau()->blogs->button_args ;
 
-		// If we pass through parent classes add them to $button array
-		$parent_class = '';
-		if ( ! empty( $args['parent_attr']['class'] ) ) {
-			$parent_class = esc_html( $args['parent_attr']['class'] );
-		}
+			// If we pass through parent classes add them to $button array
+			$parent_class = '';
+			if ( ! empty( $args['parent_attr']['class'] ) ) {
+				$parent_class = esc_html( $args['parent_attr']['class'] );
+			}
 
 			$buttons['visit_blog'] = array(
 				'id'                => 'visit_blog',
@@ -244,11 +240,12 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 				'must_be_logged_in' => $button_args['must_be_logged_in'],
 				'block_self'        => $button_args['block_self'],
 				'parent_element'    => $parent_element,
+				'button_element'    => $button_element,
+				'link_text'         => $button_args['link_text'],
 				'parent_attr'       => array(
 					'id'              => $button_args['wrapper_id'],
 					'class'           => $parent_class,
 				),
-				'button_element'    => $button_element,
 				'button_attr'       => array(
 					'href'             => $button_args['link_href'],
 					'id'               => $button_args['link_id'],
@@ -256,14 +253,13 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 					'rel'              => $button_args['link_rel'],
 					'title'            => '',
 				),
-				'link_text'         => $button_args['link_text'],
 			);
 
 			unset( bp_nouveau()->blogs->button_args );
 		}
 
 		/**
-		 * Filter here to add your buttons, use the position argument to choose where to insert it.
+		 * Filter to add your buttons, use the position argument to choose where to insert it.
 		 *
 		 * @since 1.0.0
 		 *
@@ -273,7 +269,7 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 		 */
 		$buttons_group = apply_filters( 'bp_nouveau_get_blogs_buttons', $buttons, $blog, $type );
 
-		if ( empty( $buttons_group ) ) {
+		if ( ! $buttons_group ) {
 			return $buttons;
 		}
 

--- a/bp-templates/bp-nouveau/includes/functions.php
+++ b/bp-templates/bp-nouveau/includes/functions.php
@@ -1083,7 +1083,7 @@ function bp_nouveau_theme_cover_image( $params = array() ) {
  */
 function bp_nouveau_get_user_feedback( $feedback_id = '' ) {
 	/**
-	 * Filter here to add your custom feedback messages
+	 * Filter to add your custom feedback messages
 	 *
 	 * @param array $value The list of feedback messages.
 	 */
@@ -1287,7 +1287,7 @@ function bp_nouveau_get_signup_fields( $section = '' ) {
 	}
 
 	/**
-	 * Filter here to add your specific 'text' or 'password' inputs
+	 * Filter to add your specific 'text' or 'password' inputs
 	 *
 	 * If you need to use other types of field, please use the
 	 * do_action( 'bp_account_details_fields' ) or do_action( 'blog_details' )

--- a/bp-templates/bp-nouveau/includes/functions.php
+++ b/bp-templates/bp-nouveau/includes/functions.php
@@ -223,23 +223,21 @@ function bp_nouveau_ajax_button( $output ='', $button = null, $before ='', $afte
  *
  *     @type string      $output             The HTML to output. Required.
  * }
- * @return string       HTML Output
  */
 function bp_nouveau_wrapper( $args = array() ) {
 
-/*
+ /**
 	* Classes need to be determined & set by component to a certain degree
 	*
 	* Check the component to find a default container_class to add
 	*/
-// 'activity-meta'
 	$current_component_class = bp_current_component() . '-meta';
 
-	if ( 'groups' === bp_current_component() && 'activity' === bp_current_action() ) :
+	if ( 'groups' === bp_current_component() && 'activity' === bp_current_action() ) {
 		$generic_class = ' activity-meta ';
-	else:
+	} else {
 		$generic_class = '';
-	endif;
+	}
 
 	$r = wp_parse_args( $args, array(
 		'container'         => 'div',

--- a/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -66,7 +66,7 @@ function bp_nouveau_groups_enqueue_scripts() {
  */
 function bp_nouveau_groups_disallow_all_members_invites( $default = false ) {
 	/**
-	 * Filter here to remove the All members nav, returning true
+	 * Filter to remove the All members nav, returning true
 	 *
 	 * @since 1.0.0
 	 *

--- a/bp-templates/bp-nouveau/includes/groups/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/groups/template-tags.php
@@ -1,4 +1,4 @@
-djpaultodo<?php
+<?php
 /**
  * Groups Template tags
  *
@@ -76,64 +76,60 @@ function bp_nouveau_after_groups_directory_content() {
 }
 
 /**
- * Fire specific hooks into the groups create template
+ * Fire specific hooks into the groups create template.
  *
  * @since 1.0.0
+ * @since 1.2.0 (BuddyPress) for no suffix
+ * @since 1.6.0 (BuddyPress) for the 'content_template' suffix
+ * @since 1.7.0 (BuddyPress) for the 'page' suffix
  *
- * @param string $when    'before' or 'after'
- * @param string $suffix  Use it to add terms at the end of the hook name
+ * @param string $when   Either 'before' or 'after'.
+ * @param string $suffix Use it to add terms at the end of the hook name.
  */
 function bp_nouveau_groups_create_hook( $when = '', $suffix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( $when ) {
 		$hook[] = $when;
 	}
 
 	// It's a create group hook
 	$hook[] = 'create_group';
 
-	if ( ! empty( $suffix ) ) {
+	if ( $suffix ) {
 		$hook[] = $suffix;
 	}
 
-	/**
-	 * @since 1.2.0 (BuddyPress) for no suffix
-	 * @since 1.6.0 (BuddyPress) for the 'content_template' suffix
-	 * @since 1.7.0 (BuddyPress) for the 'page' suffix
-	 */
 	bp_nouveau_hook( $hook );
 }
 
 /**
- * Fire specific hooks into the single groups templates
+ * Fire specific hooks into the single groups templates.
  *
  * @since 1.0.0
+ * @since 1.1.0 (BuddyPress) for the 'menu_admins', 'menu_mods', 'members_content',
+ *                           'members_list', 'members_list_item', 'request_membership_content'
+ *                           'membership_requests_admin_item', 'invites_item', 'invites_content' suffixes
+ * @since 1.2.0 (BuddyPress) for the 'activity_content', 'header_meta', 'home_content',
+ *                           'plugin_template', 'friend_requests_content' suffixes.
  *
- * @param string $when    'before' or 'after'
- * @param string $suffix  Use it to add terms at the end of the hook name
+ * @param string $when   Either 'before' or 'after'.
+ * @param string $suffix Use it to add terms at the end of the hook name.
  */
 function bp_nouveau_group_hook( $when = '', $suffix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( ! $when ) {
 		$hook[] = $when;
 	}
 
 	// It's a group hook
 	$hook[] = 'group';
 
-	if ( ! empty( $suffix ) ) {
+	if ( $suffix ) {
 		$hook[] = $suffix;
 	}
 
-	/**
-	 * @since 1.1.0 (BuddyPress) for the 'menu_admins', 'menu_mods', 'members_content',
-	 *                           'members_list', 'members_list_item', 'request_membership_content'
-	 *                           'membership_requests_admin_item', 'invites_item', 'invites_content' suffixes
-	 * @since 1.2.0 (BuddyPress) for the 'activity_content', 'header_meta', 'home_content',
-	 *                           'plugin_template', 'friend_requests_content' suffixes.
-	 */
 	bp_nouveau_hook( $hook );
 }
 
@@ -155,8 +151,6 @@ function bp_nouveau_groups_loop_item() {
  * Display the current group activity post form if needed
  *
  * @since 1.0.0
- *
- * @return string HTML Outpur
  */
 function bp_nouveau_groups_activity_post_form() {
 	/**
@@ -208,7 +202,7 @@ function bp_nouveau_group_invites_interface() {
  *
  * @since 1.0.0
  *
- * @return int 1 if user chose to restrict to friends. O otherwise.
+ * @return int Returns 1 if user chose to restrict to friends, 0 otherwise.
  */
 function bp_nouveau_groups_get_group_invites_setting() {
 	return (int) bp_get_user_meta( bp_displayed_user_id(), '_bp_nouveau_restrict_invites_to_friends' );
@@ -219,16 +213,16 @@ function bp_nouveau_groups_get_group_invites_setting() {
  *
  * @since 1.0.0
  *
- * @return string HTML Output
+ * @todo This output isn't localised correctly.
  */
 function bp_nouveau_group_creation_tabs() {
 	$bp = buddypress();
 
-	if ( !is_array( $bp->groups->group_creation_steps ) ) {
-		return false;
+	if ( ! is_array( $bp->groups->group_creation_steps ) ) {
+		return;
 	}
 
-	if ( !bp_get_groups_current_create_step() ) {
+	if ( ! bp_get_groups_current_create_step() ) {
 		$keys = array_keys( $bp->groups->group_creation_steps );
 		$bp->groups->current_create_step = array_shift( $keys );
 	}
@@ -240,11 +234,11 @@ function bp_nouveau_group_creation_tabs() {
 
 		<li<?php if ( bp_get_groups_current_create_step() === $slug ) : ?> class="current"<?php endif; ?>>
 			<?php if ( $is_enabled ) : ?>
-				<a href="<?php bp_groups_directory_permalink(); ?>create/step/<?php echo $slug ?>/">
-					<?php echo $counter ?> <?php echo $step['name'] ?>
+				<a href="<?php echo esc_url( bp_groups_directory_permalink() . 'create/step/' . $slug . '/' ); ?>">
+					<?php echo (int) $counter ?> <?php echo esc_html( $step['name'] ); ?>
 				</a>
 			<?php else: ?>
-				<a disabled="disabled"><?php echo $counter ?>. <?php echo $step['name'] ?></a>
+				<a disabled="disabled"><?php echo (int) $counter ?>. <?php echo esc_html( $step['name'] ); ?></a>
 			<?php endif ?>
 		</li>
 			<?php
@@ -266,8 +260,6 @@ function bp_nouveau_group_creation_tabs() {
  * Load the requested Create Screen for the new group.
  *
  * @since 1.0.0
- *
- * @return string HTML Output.
  */
 function bp_nouveau_group_creation_screen() {
 	return bp_nouveau_group_manage_screen();
@@ -277,8 +269,6 @@ function bp_nouveau_group_creation_screen() {
  * Load the requested Manage Screen for the current group.
  *
  * @since 1.0.0
- *
- * @return string HTML Output.
  */
 
 function bp_nouveau_group_manage_screen() {
@@ -311,7 +301,7 @@ function bp_nouveau_group_manage_screen() {
 		$core_screen = bp_nouveau_group_get_core_create_screens( $screen_id );
 	}
 
-	if ( false === $core_screen ) {
+	if ( ! $core_screen ) {
 		if ( ! $is_group_create ) {
 			/**
 			 * Fires inside the group admin template.
@@ -397,7 +387,7 @@ function bp_nouveau_group_manage_screen() {
 			if ( ! bp_is_first_group_creation_step() ) {
 				$creation_step_buttons .= sprintf( '<input type="button" value="%1$s" id="group-creation-previous" name="previous" onclick="%2$s" />',
 					esc_attr__( 'Back to Previous Step', 'buddypress' ),
-					"location.href='" . esc_url( bp_get_group_creation_previous_link() ) . "'"
+					esc_js( "location.href='" . esc_url_raw( bp_get_group_creation_previous_link() ) . "'" )
 				);
 			}
 
@@ -431,8 +421,10 @@ function bp_nouveau_group_manage_screen() {
 		do_action( 'bp_after_group_creation_step_buttons' );
 	}
 
-	// This way we are absolutely sure this hidden field won't be removed from the template :)
-	printf( '<input type="hidden" name="group-id" id="group-id" value="%s" />', $is_group_create ? bp_get_new_group_id() : bp_get_group_id() );
+	printf(
+		'<input type="hidden" name="group-id" id="group-id" value="%s" />',
+		$is_group_create ? esc_attr( bp_get_new_group_id() ) : esc_attr( bp_get_group_id() )
+	);
 
 	// The submit actions
 	echo $output;
@@ -461,8 +453,7 @@ function bp_nouveau_group_manage_screen() {
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_group_header_buttons( $args = array() ) {
 	$bp_nouveau = bp_nouveau();
@@ -485,15 +476,15 @@ function bp_nouveau_group_header_buttons( $args = array() ) {
 	do_action( 'bp_group_header_actions' );
 	$output .= ob_get_clean();
 
-	if ( empty( $output ) ) {
+	if ( ! $output ) {
 		return;
 	}
 
-	if ( empty( $args ) ) {
+	if ( ! $args ) {
 		$args = array( 'classes' => array( 'item-buttons' ) );
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 /**
@@ -501,8 +492,7 @@ function bp_nouveau_group_header_buttons( $args = array() ) {
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_groups_loop_buttons( $args = array() ) {
 	if ( empty( $GLOBALS['groups_template'] ) ) {
@@ -522,11 +512,11 @@ function bp_nouveau_groups_loop_buttons( $args = array() ) {
 	do_action( 'bp_directory_groups_actions' );
 	$output .= ob_get_clean();
 
-	if ( empty( $output ) ) {
+	if ( ! $output ) {
 		return;
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 /**
@@ -534,8 +524,7 @@ function bp_nouveau_groups_loop_buttons( $args = array() ) {
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_groups_invite_buttons( $args = array() ) {
 	if ( empty( $GLOBALS['groups_template'] ) ) {
@@ -555,11 +544,11 @@ function bp_nouveau_groups_invite_buttons( $args = array() ) {
 	do_action( 'bp_group_invites_item_action' );
 	$output .= ob_get_clean();
 
-	if ( empty( $output ) ) {
+	if ( ! $output ) {
 		return;
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 /**
@@ -567,8 +556,7 @@ function bp_nouveau_groups_invite_buttons( $args = array() ) {
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_groups_request_buttons( $args = array() ) {
 	if ( empty( $GLOBALS['requests_template'] ) ) {
@@ -588,11 +576,11 @@ function bp_nouveau_groups_request_buttons( $args = array() ) {
 	do_action( 'bp_group_membership_requests_admin_item_action' );
 	$output .= ob_get_clean();
 
-	if ( empty( $output ) ) {
+	if ( ! $output ) {
 		return;
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 /**
@@ -600,8 +588,7 @@ function bp_nouveau_groups_request_buttons( $args = array() ) {
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 	if ( empty( $GLOBALS['members_template'] ) ) {
@@ -621,28 +608,29 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 	do_action( 'bp_group_manage_members_admin_item' );
 	$output .= ob_get_clean();
 
-	if ( empty( $output ) ) {
+	if ( ! $output ) {
 		return;
 	}
 
-	if ( empty( $args ) ) {
+	if ( ! $args ) {
 		$args = array( 'wrapper' => 'span', 'classes' => array( 'small' ) );
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 	/**
 	 * Get the action buttons for the current group in the loop,
-	 * or the current displayed group
+	 * or the current displayed group.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.
 	 */
-	function bp_nouveau_get_groups_buttons( $args ) {
-
+	function bp_nouveau_get_groups_buttons( $args = array() ) {
 		$type = ( ! empty( $args['type'] ) ) ? $args['type'] : 'group';
 
-		// Not really sure why BP Legacy needed to do this...
+		// @todo Not really sure why BP Legacy needed to do this...
 		if ( 'group' === $type && is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			return;
 		}
@@ -668,7 +656,7 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 		if ( ! empty( $args['container'] ) && 'ul' === $args['container']  ) {
 			$parent_element = 'li';
 		} elseif ( ! empty( $args['parent_element'] ) ) {
-			$parent_element = esc_html( $args['parent_element'] );
+			$parent_element = $args['parent_element'];
 		} else {
 			$parent_element = false;
 		}
@@ -692,7 +680,7 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 		// If we pass through parent classes add them to $button array
 		$parent_class = '';
 		if ( ! empty( $args['parent_attr']['class'] ) ) {
-			$parent_class = esc_html( $args['parent_attr']['class'] );
+			$parent_class = $args['parent_attr']['class'];
 		}
 
 		// Invite buttons on member's invites screen
@@ -710,17 +698,17 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 				'component'         => 'groups',
 				'must_be_logged_in' => true,
 				'parent_element'    => $parent_element,
-				'parent_attr'       => array(
-					'id'               => '',
-					'class'            => $parent_class . ' ' . 'accept',
-				 ),
-				'button_element'    => $button_element,
-				'button_attr'       => array(
-					'id'               => '',
-					'class'            => 'button accept group-button accept-invite',
-					'rel'              => '',
-				 ),
 				'link_text'         => esc_html__( 'Accept', 'buddypress' ),
+				'button_element'    => $button_element,
+				'parent_attr'       => array(
+					'id'    => '',
+					'class' => $parent_class . ' ' . 'accept',
+				),
+				'button_attr'       => array(
+					'id'    => '',
+					'class' => 'button accept group-button accept-invite',
+					'rel'   => '',
+				),
 			);
 
 			// If button element set add nonce link to data-attr attr
@@ -737,17 +725,17 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 				'component'         => 'groups',
 				'must_be_logged_in' => true,
 				'parent_element'    => $parent_element,
+				'link_text'         => __( 'Reject', 'buddypress' ),
 				'parent_attr'       => array(
-					'id'               => '',
-					'class'            => $parent_class . ' ' . 'reject',
-				 ),
+					'id'    => '',
+					'class' => $parent_class . ' ' . 'reject',
+				),
 				'button_element'    => $button_element,
 				'button_attr'       => array(
-					'id'               => '',
-					'class'            => 'button reject group-button reject-invite',
-					'rel'              => '',
-				 ),
-				'link_text'         => __( 'Reject', 'buddypress' ),
+					'id'    => '',
+					'class' => 'button reject group-button reject-invite',
+					'rel'   => '',
+				),
 			);
 
 			// If button element set add nonce link to formaction attr
@@ -760,24 +748,23 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 		// Request button for the group's manage screen
 		} elseif ( 'request' === $type ) {
 			// Setup Accept button attributes
-
 			$buttons['group_membership_accept'] =  array(
 				'id'                => 'group_membership_accept',
 				'position'          => 5,
 				'component'         => 'groups',
 				'must_be_logged_in' => true,
 				'parent_element'    => $parent_element,
-				'parent_attr'       => array(
-					'id'               => '',
-					'class'            => $parent_class . ' ' . 'accept',
-				 ),
-				'button_element'    => $button_element,
-				'button_attr'       => array(
-					'id'               => '',
-					'class'            => 'button',
-					'rel'              => '',
-				 ),
 				'link_text'         => esc_html__( 'Accept', 'buddypress' ),
+				'button_element'    => $button_element,
+				'parent_attr'       => array(
+					'id'    => '',
+					'class' => $parent_class . ' ' . 'accept',
+				),
+				'button_attr'       => array(
+					'id'    => '',
+					'class' => 'button',
+					'rel'   => '',
+				),
 			);
 
 			// If button element set add nonce link to data-attr attr
@@ -793,17 +780,17 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 				'component'         => 'groups',
 				'must_be_logged_in' => true,
 				'parent_element'    => $parent_element,
-				'parent_attr'       => array(
-					'id'               => '',
-					'class'            => $parent_class . ' ' . 'reject',
-					),
 				'button_element'    => $button_element,
-				'button_attr'       => array(
-					'id'               => '',
-					'class'            => 'button',
-					'rel'              => '',
-					),
 				'link_text'         => __( 'Reject', 'buddypress' ),
+				'parent_attr'       => array(
+					'id'    => '',
+					'class' => $parent_class . ' ' . 'reject',
+				),
+				'button_attr'       => array(
+					'id'    => '',
+					'class' => 'button',
+					'rel'   => '',
+				),
 			);
 
 			// If button element set add nonce link to data-attr attr
@@ -814,59 +801,60 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 			}
 
 		/*
-		Manage group members for the group's manage screen
-		The 'button_attr' keys 'href' & 'formaction' are set at the end of this array block
-		*/
+		 * Manage group members for the group's manage screen.
+		 * The 'button_attr' keys 'href' & 'formaction' are set at the end of this array block
+		 */
 		} elseif ( 'manage_members' === $type && isset( $GLOBALS['members_template']->member->user_id ) ) {
 			$user_id = $GLOBALS['members_template']->member->user_id;
 
-			$buttons = array( 'unban_member' => array(
-				'id'                => 'unban_member',
-				'position'          => 5,
-				'component'         => 'groups',
-				'must_be_logged_in' => true,
-				'parent_element'    => $parent_element,
-				'parent_attr'       => array(
-					'id'               => '',
-					'class'            => $parent_class,
-					),
-				'button_element'    => $button_element,
-				'button_attr'       => array(
-					'id'               => '',
-					'class'            => 'button confirm member-unban',
-					'rel'              => '',
-					'title'            => '',
-					),
+			$buttons = array(
+				'unban_member' => array(
+					'id'                => 'unban_member',
+					'position'          => 5,
+					'component'         => 'groups',
+					'must_be_logged_in' => true,
+					'parent_element'    => $parent_element,
+					'button_element'    => $button_element,
 					'link_text'         => __( 'Remove Ban', 'buddypress' ),
-
-				), 'ban_member' => array(
-				'id'                => 'ban_member',
-				'position'          => 15,
-				'component'         => 'groups',
-				'must_be_logged_in' => true,
-				'parent_element'    => $parent_element,
-				'parent_attr'       => array(
-					'id'               => '',
-					'class'            => $parent_class,
+					'parent_attr'       => array(
+						'id'    => '',
+						'class' => $parent_class,
 					),
-				'button_element'    => $button_element,
-				'button_attr'       => array(
-					'id'               => '',
-					'class'            => 'button confirm member-ban',
-					'rel'              => '',
-					'title'            => '',
+					'button_attr'       => array(
+						'id'    => '',
+						'class' => 'button confirm member-unban',
+						'rel'   => '',
+						'title' => '',
 					),
-				'link_text'         => __( 'Kick &amp; Ban', 'buddypress' ),
-
-				), 'promote_mod' => array(
+				),
+				'ban_member' => array(
+					'id'                => 'ban_member',
+					'position'          => 15,
+					'component'         => 'groups',
+					'must_be_logged_in' => true,
+					'parent_element'    => $parent_element,
+					'button_element'    => $button_element,
+					'link_text'         => __( 'Kick &amp; Ban', 'buddypress' ),
+					'parent_attr'       => array(
+						'id'    => '',
+						'class' => $parent_class,
+					),
+					'button_attr'       => array(
+						'id'    => '',
+						'class' => 'button confirm member-ban',
+						'rel'   => '',
+						'title' => '',
+					),
+				),
+				'promote_mod' => array(
 					'id'                => 'promote_mod',
 					'position'          => 25,
 					'component'         => 'groups',
 					'must_be_logged_in' => true,
 					'parent_element'    => $parent_element,
 					'parent_attr'       => array(
-						'id'               => '',
-						'class'            => $parent_class,
+						'id'    => '',
+						'class' => $parent_class,
 					),
 					'button_element'    => $button_element,
 					'button_attr'       => array(
@@ -876,70 +864,71 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 						'title'            => '',
 					),
 					'link_text'         => __( 'Promote to Mod', 'buddypress' ),
-
-				), 'promote_admin' => array(
+				),
+				'promote_admin' => array(
 					'id'                => 'promote_admin',
 					'position'          => 35,
 					'component'         => 'groups',
 					'must_be_logged_in' => true,
 					'parent_element'    => $parent_element,
-					'parent_attr'       => array(
-						'id'               => '',
-						'class'            => $parent_class,
-					),
 					'button_element'    => $button_element,
-					'button_attr'       => array(
-						'href'             => esc_url( bp_get_group_member_promote_admin_link() ),
-						'id'               => '',
-						'class'            => 'button confirm member-promote-to-admin',
-						'rel'              => '',
-						'title'            => '',
-					),
 					'link_text'         => __( 'Promote to Admin', 'buddypress' ),
-
-				), 'remove_member' => array(
+					'parent_attr'       => array(
+						'id'    => '',
+						'class' => $parent_class,
+					),
+					'button_attr'       => array(
+						'href'  => esc_url( bp_get_group_member_promote_admin_link() ),
+						'id'    => '',
+						'class' => 'button confirm member-promote-to-admin',
+						'rel'   => '',
+						'title' => '',
+					),
+				),
+				'remove_member' => array(
 					'id'                => 'remove_member',
 					'position'          => 45,
 					'component'         => 'groups',
 					'must_be_logged_in' => true,
 					'parent_element'    => $parent_element,
-					'parent_attr'       => array(
-						'id'               => '',
-						'class'            => $parent_class,
-					),
 					'button_element'    => $button_element,
-					'button_attr'       => array(
-						'id'               => '',
-						'class'            => 'button confirm',
-						'rel'              => '',
-						'title'            => '',
-					),
 					'link_text'         => __( 'Remove from group', 'buddypress' ),
+					'parent_attr'       => array(
+						'id'    => '',
+						'class' => $parent_class,
+					),
+					'button_attr'       => array(
+						'id'    => '',
+						'class' => 'button confirm',
+						'rel'   => '',
+						'title' => '',
+					),
 				),
 			);
-			// If 'button' element is set add the nonce link to data-attr attr
-			// else add it to the href.
+
+			// If 'button' element is set add the nonce link to data-attr attr, else add it to the href.
 			if ( 'button' === $button_element ) {
-				$buttons['unban_member']['button_attr']['data-bp-nonce'] = esc_url( bp_get_group_member_unban_link( $user_id ) );
-				$buttons['ban_member']['button_attr']['data-bp-nonce'] = esc_url( bp_get_group_member_ban_link( $user_id ) );
-				$buttons['promote_mod']['button_attr']['data-bp-nonce'] = esc_url( bp_get_group_member_promote_mod_link() );
-				$buttons['promote_admin']['button_attr']['data-bp-nonce'] = esc_url( bp_get_group_member_promote_admin_link() );
-				$buttons['remove_member']['button_attr']['data-bp-nonce'] = esc_url( bp_get_group_member_remove_link( $user_id ) );
+				$buttons['unban_member']['button_attr']['data-bp-nonce'] = bp_get_group_member_unban_link( $user_id );
+				$buttons['ban_member']['button_attr']['data-bp-nonce'] = bp_get_group_member_ban_link( $user_id );
+				$buttons['promote_mod']['button_attr']['data-bp-nonce'] = bp_get_group_member_promote_mod_link();
+				$buttons['promote_admin']['button_attr']['data-bp-nonce'] = bp_get_group_member_promote_admin_link();
+				$buttons['remove_member']['button_attr']['data-bp-nonce'] = bp_get_group_member_remove_link( $user_id );
 			} else {
-				$buttons['unban_member']['button_attr']['href'] = esc_url( bp_get_group_member_unban_link( $user_id ) );
-				$buttons['ban_member']['button_attr']['href'] = esc_url( bp_get_group_member_ban_link( $user_id ) );
-				$buttons['promote_mod']['button_attr']['href'] = esc_url( bp_get_group_member_promote_mod_link() );
-				$buttons['promote_admin']['button_attr']['href'] = esc_url( bp_get_group_member_promote_admin_link() );
-				$buttons['remove_member']['button_attr']['href'] = esc_url( bp_get_group_member_remove_link( $user_id ) );
+				$buttons['unban_member']['button_attr']['href'] = bp_get_group_member_unban_link( $user_id );
+				$buttons['ban_member']['button_attr']['href'] = bp_get_group_member_ban_link( $user_id );
+				$buttons['promote_mod']['button_attr']['href'] = bp_get_group_member_promote_mod_link();
+				$buttons['promote_admin']['button_attr']['href'] = bp_get_group_member_promote_admin_link();
+				$buttons['remove_member']['button_attr']['href'] = bp_get_group_member_remove_link( $user_id );
 			}
 
 		// Membership button on groups loop or single group's header
 		} else {
-			/**
+			/*
 			 * This filter workaround is waiting for a core adaptation
 			 * so that we can directly get the groups button arguments
 			 * instead of the button.
-			 * @see https://buddypress.trac.wordpress.org/ticket/7126
+			 *
+			 * See https://buddypress.trac.wordpress.org/ticket/7126
 			 */
 			add_filter( 'bp_get_group_join_button', 'bp_nouveau_groups_catch_button_args', 100, 1 );
 
@@ -951,7 +940,7 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 				$button_args = bp_nouveau()->groups->button_args;
 
 				// If we pass through parent classes merge those into the existing ones
-				if ( ! empty( $parent_class ) ) {
+				if ( $parent_class ) {
 					$parent_class .= ' ' . $button_args['wrapper_class'];
 				}
 
@@ -962,20 +951,19 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 					'must_be_logged_in' => $button_args['must_be_logged_in'],
 					'block_self'        => $button_args['block_self'],
 					'parent_element'    => $parent_element,
-					'parent_attr'       => array(
-							'id'              => $button_args['wrapper_id'],
-							'class'           => $parent_class,
-					),
 					'button_element'    => $button_element,
-					'button_attr'       => array(
-						'href'             => $button_args['link_href'],
-						'id'               => ! empty( $button_args['link_id'] ) ? $button_args['link_id'] : '',
-						'class'            => $button_args['link_class'] . ' button',
-						'rel'              => ! empty( $button_args['link_rel'] ) ? $button_args['link_rel'] : '',
-						'title'            => '',
-					),
-
 					'link_text'         => $button_args['link_text'],
+					'parent_attr'       => array(
+							'id'    => $button_args['wrapper_id'],
+							'class' => $parent_class,
+					),
+					'button_attr'       => array(
+						'href'  => $button_args['link_href'],
+						'id'    => ! empty( $button_args['link_id'] ) ? $button_args['link_id'] : '',
+						'class' => $button_args['link_class'] . ' button',
+						'rel'   => ! empty( $button_args['link_rel'] ) ? $button_args['link_rel'] : '',
+						'title' => '',
+					),
 				);
 
 			// If button element set add nonce link to data-attr attr
@@ -1000,12 +988,12 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 		 */
 		$buttons_group = apply_filters( 'bp_nouveau_get_groups_buttons', $buttons, $group, $type );
 
-		if ( empty( $buttons_group ) ) {
+		if ( ! $buttons_group ) {
 			return $buttons;
 		}
 
 		// It's the first entry of the loop, so build the Group and sort it
-		if ( ! isset( bp_nouveau()->groups->group_buttons ) || false === is_a( bp_nouveau()->groups->group_buttons, 'BP_Buttons_Group' ) ) {
+		if ( ! isset( bp_nouveau()->groups->group_buttons ) || ! is_a( bp_nouveau()->groups->group_buttons, 'BP_Buttons_Group' ) ) {
 			$sort = true;
 			bp_nouveau()->groups->group_buttons = new BP_Buttons_Group( $buttons_group );
 
@@ -1080,10 +1068,13 @@ function bp_nouveau_group_meta() {
 		echo join( ' / ', array_map( 'esc_html', (array) $meta ) );
 	} else {
 
-		/**
-		* Lets return an object not echo an array here for the single groups,
-		* more flexible for the template!!?? ~hnla
-		*/
+		/*
+		 * Lets return an object not echo an array here for the single groups,
+		 * more flexible for the template!!?? ~hnla
+		 *
+		 * @todo Paul says that a function that prints and/or returns a value,
+		 * depending on global state, is madness. This needs changing.
+		 */
 		//echo join( "\n", $meta );
 		return  (object) bp_nouveau_get_group_meta();
 	}
@@ -1097,13 +1088,11 @@ function bp_nouveau_group_meta() {
 	 * @return array The group meta.
 	 */
 	function bp_nouveau_get_group_meta() {
-
-/**
- * @todo For brevity required approapriate markup is added here as strings
- * this needs to be either filterable or the function needs to be able to accept
- * & parse args!
- */
-
+		/*
+		 * @todo For brevity required approapriate markup is added here as strings
+		 * this needs to be either filterable or the function needs to be able to accept
+		 * & parse args!
+		 */
 		$meta     = array();
 		$is_group = bp_is_group();
 
@@ -1118,7 +1107,7 @@ function bp_nouveau_group_meta() {
 		if ( empty( $group->template_meta ) ) {
 			// It's a single group
 			if ( $is_group ) {
-				/**
+				/*
 				 * If the Group's default front page isn't set to display
 				 * the description inside it, include the description to metas
 				 */
@@ -1164,8 +1153,6 @@ function bp_nouveau_group_meta() {
  * Load the appropriate content for the single group pages
  *
  * @since 1.0.0
- *
- * @return string HTML Output.
  */
 function bp_nouveau_group_template_part() {
 	/**
@@ -1242,8 +1229,6 @@ function bp_nouveau_group_template_part() {
  * Use the appropriate Group header and enjoy a template hierarchy
  *
  * @since 1.0.0
- *
- * @return string HTML Output
  */
 function bp_nouveau_group_header_template_part() {
 	$template = 'group-header';
@@ -1309,58 +1294,47 @@ function bp_nouveau_groups_get_customizer_widgets_link() {
  *
  * @since 1.0.0
  *
- * @param object|bool  $group  Optional. The group being referenced.
-	*                             Defaults to the group currently being
-	*                             iterated on in the groups loop.
-	* @param int          $length Optional. Length of returned string, including ellipsis.
-	*                             Default: 225.
-	* @return string Excerpt.
+ * @param object $group  Optional. The group being referenced.
+ *                       Defaults to the group currently being
+ *                       iterated on in the groups loop.
+ * @param int $length    Optional. Length of returned string, including ellipsis.
+ *                       Default: 100.
+ *
+ * @return string Excerpt.
  *
  */
-function bp_nouveau_group_description_excerpt( $group = false, $length = false) {
-	echo bp_nouveau_get_group_description_excerpt( $group, $length);
+function bp_nouveau_group_description_excerpt( $group = null, $length = 100 ) {
+	echo bp_nouveau_get_group_description_excerpt( $group, $length );
 }
 
 /**
-* Filters the excerpt  of a group description.
-*
-* Checks if the group loop is set as a 'Grid' layout and returns a reduced excerpt.
-*
-* @since 1.0.0
-*
-* @param object|bool  $group  Optional. The group being referenced.
-*                             Defaults to the group currently being
-*                             iterated on in the groups loop.
-* @param int          $length Optional. Length of returned string, including ellipsis.
-*                             Default: 225.
-* @return string Excerpt.
-*/
-function bp_nouveau_get_group_description_excerpt( $group =false, $length = false) {
+ * Filters the excerpt  of a group description.
+ *
+ * Checks if the group loop is set as a 'Grid' layout and returns a reduced excerpt.
+ *
+ * @since 1.0.0
+ *
+ * @param object $group  Optional. The group being referenced.
+ *                       Defaults to the group currently being
+ *                       iterated on in the groups loop.
+ * @param int $length    Optional. Length of returned string, including ellipsis.
+ *                       Default: 100.
+ * @return string Excerpt.
+ */
+function bp_nouveau_get_group_description_excerpt( $group = null, $length = 100 ) {
 	global $groups_template;
 
-	if ( empty( $group ) ) {
+	if ( ! $group ) {
 		$group =& $groups_template->group;
 	}
 
-	// If this is a grid layout but no length is passed in set shorter
-	// default value otherwise use the passed in value.
-	// If not a grid then the BP core default is used or passed in value.
-	if ( bp_nouveau_loop_is_grid() && 'groups' === bp_current_component() ) {
-		if ( false === $length ) {
-			$length = 100;
-		} elseif ( $length ) {
-			$length = $length;
-		}
-	}
-
 	/**
-		* Filters the excerpt of a group description.
-		*
-		* @since 1.0.0
-		*
-		* @param string $value Excerpt of a group description.
-		* @param object $group Object for group whose description is made into an excerpt.
-		*/
-
+	 * Filters the excerpt of a group description.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $value Excerpt of a group description.
+	 * @param object $group Object for group whose description is made into an excerpt.
+	 */
 	return apply_filters( 'bp_nouveau_get_group_description_excerpt', bp_create_excerpt( $group->description, $length ), $group );
 }

--- a/bp-templates/bp-nouveau/includes/groups/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/groups/template-tags.php
@@ -1,4 +1,4 @@
-<?php
+djpaultodo<?php
 /**
  * Groups Template tags
  *
@@ -990,7 +990,7 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 		}
 
 		/**
-		 * Filter here to add your buttons, use the position argument to choose where to insert it.
+		 * Filter to add your buttons, use the position argument to choose where to insert it.
 		 *
 		 * @since 1.0.0
 		 *
@@ -1146,7 +1146,7 @@ function bp_nouveau_group_meta() {
 			}
 
 			/**
-			 * Filter here to add/remove Group meta.
+			 * Filter to add/remove Group meta.
 			 *
 			 * @since 1.0.0
 			 *
@@ -1284,7 +1284,7 @@ function bp_nouveau_groups_get_customizer_option_link() {
 	return bp_nouveau_get_customizer_link( array(
 		'object'    => 'group',
 		'autofocus' => 'bp_nouveau_group_front_page',
-		'text'      => esc_html__( 'Groups default front page', 'buddypress' ),
+		'text'      => __( 'Groups default front page', 'buddypress' ),
 	) );
 }
 
@@ -1300,7 +1300,7 @@ function bp_nouveau_groups_get_customizer_widgets_link() {
 	return bp_nouveau_get_customizer_link( array(
 		'object'    => 'group',
 		'autofocus' => 'sidebar-widgets-sidebar-buddypress-groups',
-		'text'      => esc_html__( '(BuddyPress) Widgets', 'buddypress' ),
+		'text'      => __( '(BuddyPress) Widgets', 'buddypress' ),
 	) );
 }
 

--- a/bp-templates/bp-nouveau/includes/members/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/members/template-tags.php
@@ -1,4 +1,4 @@
-<?php
+djpaultodo<?php
 /**
  * Members template tags
  *
@@ -477,7 +477,7 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 		}
 
 		/**
-		 * Filter here to add your buttons, use the position argument to choose where to insert it.
+		 * Filter to add your buttons, use the position argument to choose where to insert it.
 		 *
 		 * @since 1.0.0
 		 *
@@ -586,7 +586,7 @@ function bp_nouveau_member_meta() {
 			}
 
 			/**
-			 * Filter here to add/remove Member meta.
+			 * Filter to add/remove Member meta.
 			 *
 			 * @since 1.0.0
 			 *
@@ -693,7 +693,7 @@ function bp_nouveau_members_get_customizer_option_link() {
 	return bp_nouveau_get_customizer_link( array(
 		'object'    => 'user',
 		'autofocus' => 'bp_nouveau_user_front_page',
-		'text'      => esc_html__( 'Members default front page', 'buddypress' ),
+		'text'      => __( 'Members default front page', 'buddypress' ),
 	) );
 }
 
@@ -709,7 +709,7 @@ function bp_nouveau_members_get_customizer_widgets_link() {
 	return bp_nouveau_get_customizer_link( array(
 		'object'    => 'user',
 		'autofocus' => 'sidebar-widgets-sidebar-buddypress-members',
-		'text'      => esc_html__( '(BuddyPress) Widgets', 'buddypress' ),
+		'text'      => __( '(BuddyPress) Widgets', 'buddypress' ),
 	) );
 }
 

--- a/bp-templates/bp-nouveau/includes/members/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/members/template-tags.php
@@ -1,4 +1,4 @@
-djpaultodo<?php
+<?php
 /**
  * Members template tags
  *
@@ -86,6 +86,10 @@ function bp_nouveau_after_members_directory_content() {
  * Fire specific hooks into the single members templates
  *
  * @since 1.0.0
+ * @since 1.2.0 (BuddyPress) for the 'activity_content', 'blogs_content', 'header_meta',
+ *                           'friends_content', 'groups_content', 'home_content', 'plugin_template'
+ *                           'friend_requests_content' suffixes.
+ * @since 1.5.0 (BuddyPress) for the 'settings_template' suffix.
  *
  * @param string $when    'before' or 'after'
  * @param string $suffix  Use it to add terms at the end of the hook name
@@ -93,23 +97,17 @@ function bp_nouveau_after_members_directory_content() {
 function bp_nouveau_member_hook( $when = '', $suffix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( $when ) {
 		$hook[] = $when;
 	}
 
 	// It's a member hook
 	$hook[] = 'member';
 
-	if ( ! empty( $suffix ) ) {
+	if ( $suffix ) {
 		$hook[] = $suffix;
 	}
 
-	/**
-	 * @since 1.2.0 (BuddyPress) for the 'activity_content', 'blogs_content', 'header_meta',
-	 *                           'friends_content', 'groups_content', 'home_content', 'plugin_template'
-	 *                           'friend_requests_content' suffixes.
-	 * @since 1.5.0 (BuddyPress) for the 'settings_template' suffix.
-	 */
 	bp_nouveau_hook( $hook );
 }
 
@@ -132,8 +130,7 @@ function bp_nouveau_member_email_notice_settings() {
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_member_header_buttons( $args = array() ) {
 	$bp_nouveau = bp_nouveau();
@@ -163,15 +160,15 @@ function bp_nouveau_member_header_buttons( $args = array() ) {
 	do_action( 'bp_member_header_actions' );
 	$output .= ob_get_clean();
 
-	if ( empty( $output ) ) {
-		return '';
+	if ( ! $output ) {
+		return;
 	}
 
-	if ( empty( $args ) ) {
+	if ( ! $args ) {
 		$args = array( 'id' => 'item-buttons', 'classes' => false );
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 /**
@@ -179,12 +176,11 @@ function bp_nouveau_member_header_buttons( $args = array() ) {
  *
  * @since 1.0.0
  *
- * @param  array $args @see bp_nouveau_wrapper() for the description of parameters.
- * @return string HTML Output
+ * @param array $args See bp_nouveau_wrapper() for the description of parameters.
  */
 function bp_nouveau_members_loop_buttons( $args = array() ) {
 	if ( empty( $GLOBALS['members_template'] ) ) {
-		return '';
+		return;
 	}
 
 	$args['type'] = 'loop';
@@ -192,10 +188,11 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 
 	// Specific case for group members.
 	if ( bp_is_active( 'groups' ) && bp_is_group_members() ) {
-		$args['type']   = 'group_member';
+		$args['type'] = 'group_member';
 		$action = 'bp_group_members_list_item_action';
+
 	} elseif ( bp_is_active( 'friends' ) && bp_is_user_friend_requests() ) {
-		$args['type']   = 'friendship_request';
+		$args['type'] = 'friendship_request';
 		$action = 'bp_friend_requests_item_action';
 	}
 
@@ -210,11 +207,11 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 	do_action( $action );
 	$output .= ob_get_clean();
 
-	if ( empty( $output ) ) {
-		return '';
+	if ( ! $output ) {
+		return;
 	}
 
-	return bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
+	bp_nouveau_wrapper( array_merge( $args, array( 'output' => $output ) ) );
 }
 
 	/**
@@ -228,17 +225,17 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 		$buttons = array();
 		$type = ( ! empty( $args['type'] ) ) ? $args['type'] : '';
 
-		// Not really sure why BP Legacy needed to do this...
+		// @todo Not really sure why BP Legacy needed to do this...
 		if ( 'profile' === $type && is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			return $buttons;
 		}
+
+		$user_id = bp_displayed_user_id();
 
 		if ( 'loop' === $type || 'friendship_request' === $type ) {
 			$user_id = bp_get_member_user_id();
 		} elseif ( 'group_member' === $type ) {
 			$user_id = bp_get_group_member_id();
-		} else {
-			$user_id = bp_displayed_user_id();
 		}
 
 		if ( ! $user_id ) {
@@ -251,12 +248,12 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 		 * otherwise simply pass any value found in args
 		 * or set var false.
 		 */
+		$parent_element = false;
+
 		if ( ! empty( $args['container'] ) && 'ul' === $args['container']  ) {
 			$parent_element = 'li';
 		} elseif ( ! empty( $args['parent_element'] ) ) {
-			$parent_element = esc_html( $args['parent_element'] );
-		} else {
-			$parent_element = false;
+			$parent_element = $args['parent_element'];
 		}
 
 		/*
@@ -278,56 +275,57 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 		// If we pass through parent classes add them to $button array
 		$parent_class = '';
 		if ( ! empty( $args['parent_attr']['class'] ) ) {
-			$parent_class = esc_html( $args['parent_attr']['class'] );
+			$parent_class = $args['parent_attr']['class'];
 		}
 
 		if ( bp_is_active( 'friends' ) ) {
 			// It's the member's friendship requests screen
 			if ( 'friendship_request' === $type ) {
-				$buttons = array( 'accept_friendship' => array(
+				$buttons = array(
+					'accept_friendship' => array(
 						'id'                => 'accept_friendship',
 						'position'          => 5,
 						'component'         => 'friends',
 						'must_be_logged_in' => true,
 						'parent_element'    => $parent_element,
-						'parent_attr'       => array(
-							'id'               => '',
-							'class'            => $parent_class ,
-							),
-						'button_element'    => $button_element,
-						'button_attr'       => array (
-							'class'            => 'button accept bp-tooltip',
-							'rel'              => '',
-							'data-bp-tooltip'  => __( 'Accept', 'buddypress' ),
-							),
 						'link_text'         => __( 'Accept', 'buddypress' ),
+						'parent_attr'       => array(
+							'id'    => '',
+							'class' => $parent_class ,
+						),
+						'button_element'    => $button_element,
+						'button_attr'       => array(
+							'class'           => 'button accept bp-tooltip',
+							'rel'             => '',
+							'data-bp-tooltip' => __( 'Accept', 'buddypress' ),
+						),
 					), 'reject_friendship' => array(
 						'id'                => 'reject_friendship',
 						'position'          => 15,
 						'component'         => 'friends',
 						'must_be_logged_in' => true,
 						'parent_element'    => $parent_element,
+						'link_text'         => __( 'Reject', 'buddypress' ),
 						'parent_attr'       => array(
-							'id'               => '',
-							'class'            => $parent_class,
-							),
+							'id'    => '',
+							'class' => $parent_class,
+						),
 						'button_element'    => $button_element,
 						'button_attr'       => array (
-							'class'            => 'button reject bp-tooltip',
-							'rel'              => '',
-							'data-bp-tooltip'  => __( 'Reject', 'buddypress' ),
-							),
-						'link_text'         => __( 'Reject', 'buddypress' ),
+							'class'           => 'button reject bp-tooltip',
+							'rel'             => '',
+							'data-bp-tooltip' => __( 'Reject', 'buddypress' ),
+						),
 					),
 				);
 
 				// If button element set add nonce link to data attr
 				if ( 'button' === $button_element ) {
-					$buttons['accept_friendship']['button_attr']['data-bp-nonce'] = esc_url( bp_get_friend_accept_request_link() );
-					$buttons['reject_friendship']['button_attr']['data-bp-nonce'] = esc_url( bp_get_friend_reject_request_link() );
+					$buttons['accept_friendship']['button_attr']['data-bp-nonce'] = bp_get_friend_accept_request_link();
+					$buttons['reject_friendship']['button_attr']['data-bp-nonce'] = bp_get_friend_reject_request_link();
 				} else {
-					$buttons['accept_friendship']['button_attr']['href'] = esc_url( bp_get_friend_accept_request_link() );
-					$buttons['reject_friendship']['button_attr']['href'] = esc_url( bp_get_friend_reject_request_link() );
+					$buttons['accept_friendship']['button_attr']['href'] = bp_get_friend_accept_request_link();
+					$buttons['reject_friendship']['button_attr']['href'] = bp_get_friend_reject_request_link();
 				}
 
 			// It's any other members screen
@@ -355,18 +353,18 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 						'must_be_logged_in' => $button_args['must_be_logged_in'],
 						'block_self'        => $button_args['block_self'],
 						'parent_element'    => $parent_element,
+						'link_text'         => $button_args['link_text'],
 						'parent_attr'       => array(
-								'id'              => $button_args['wrapper_id'],
-								'class'           => $parent_class . ' ' . $button_args['wrapper_class'],
-							),
+							'id'    => $button_args['wrapper_id'],
+							'class' => $parent_class . ' ' . $button_args['wrapper_class'],
+						),
 						'button_element'    => $button_element,
 						'button_attr'       => array(
-							'id'               => $button_args['link_id'],
-							'class'            => $button_args['link_class'],
-							'rel'              => $button_args['link_rel'],
-							'title'            => '',
-							),
-						'link_text'         => $button_args['link_text'],
+							'id'    => $button_args['link_id'],
+							'class' => $button_args['link_class'],
+							'rel'   => $button_args['link_rel'],
+							'title' => '',
+						),
 					);
 
 					// If button element set add nonce link to data attr
@@ -411,19 +409,17 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 						'must_be_logged_in' => $button_args['must_be_logged_in'],
 						'block_self'        => $button_args['block_self'],
 						'parent_element'    => $parent_element,
-						'parent_attr'       => array(
-								'id'              => $button_args['wrapper_id'],
-								'class'           => $parent_class,
-							),
 						'button_element'    => 'a',
+						'link_text'         => $button_args['link_text'],
+						'parent_attr'       => array(
+							'id'    => $button_args['wrapper_id'],
+							'class' => $parent_class,
+						),
 						'button_attr'       => array(
 							'href'             => $button_args['link_href'],
 							'id'               => '',
 							'class'            => $button_args['link_class'],
-							//'rel'              => '',
-							//'title'            => '',
-							),
-						'link_text'         => $button_args['link_text'],
+						),
 					);
 					unset( bp_nouveau()->members->button_args );
 				}
@@ -456,19 +452,19 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 						'must_be_logged_in' => $button_args['must_be_logged_in'],
 						'block_self'        => $button_args['block_self'],
 						'parent_element'    => $parent_element,
-						'parent_attr'       => array(
-								'id'              => $button_args['wrapper_id'],
-								'class'           => $parent_class,
-							),
 						'button_element'    => 'a',
-						'button_attr'       => array(
-							'href'             => esc_url( trailingslashit( bp_loggedin_user_domain() . bp_get_messages_slug() ) . '#compose?r=' . bp_core_get_username( $user_id ) ),
-							'id'               => false,
-							'class'            => $button_args['link_class'],
-							'rel'              => '',
-							'title'            => __( '', 'buddypress' ),
-							),
 						'link_text'         => $button_args['link_text'],
+						'parent_attr'       => array(
+							'id'    => $button_args['wrapper_id'],
+							'class' => $parent_class,
+						),
+						'button_attr'       => array(
+							'href'  => trailingslashit( bp_loggedin_user_domain() . bp_get_messages_slug() ) . '#compose?r=' . bp_core_get_username( $user_id ),
+							'id'    => false,
+							'class' => $button_args['link_class'],
+							'rel'   => '',
+							'title' => '',
+							),
 					);
 
 					unset( bp_nouveau()->members->button_args );
@@ -486,8 +482,7 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 		 * @param string $type    Whether we're displaying a members loop or a user's page
 		 */
 		$buttons_group = apply_filters( 'bp_nouveau_get_members_buttons', $buttons, $user_id, $type );
-
-		if ( empty( $buttons_group ) ) {
+		if ( ! $buttons_group ) {
 			return $buttons;
 		}
 
@@ -552,11 +547,11 @@ function bp_nouveau_member_meta() {
 	 * @return array The member meta.
 	 */
 	function bp_nouveau_get_member_meta() {
-		$meta     = array();
-		$is_loop  = false;
+		$meta    = array();
+		$is_loop = false;
 
 		if ( ! empty( $GLOBALS['members_template']->member ) ) {
-			$member = $GLOBALS['members_template']->member;
+			$member  = $GLOBALS['members_template']->member;
 			$is_loop = true;
 		} else {
 			$member = bp_get_displayed_user();
@@ -569,7 +564,10 @@ function bp_nouveau_member_meta() {
 		if ( empty( $member->template_meta ) ) {
 			// It's a single user's header
 			if ( ! $is_loop ) {
-				$meta['last_activity'] = sprintf( '<span class="activity">%s</span>', bp_get_last_activity( bp_displayed_user_id() ) );
+				$meta['last_activity'] = sprintf(
+					'<span class="activity">%s</span>',
+					esc_html( bp_get_last_activity( bp_displayed_user_id() ) )
+				);
 
 			// We're in the members loop
 			} else {
@@ -615,6 +613,7 @@ function bp_nouveau_member_template_part() {
 
 	if ( bp_is_user_front() ) {
 		bp_displayed_user_front_template_part();
+
 	} else {
 		$template = 'plugins';
 
@@ -718,10 +717,12 @@ function bp_nouveau_members_get_customizer_widgets_link() {
  *
  * @since 1.0.0
  *
- * @return string HTML Output
+ * @param int $user_id Optional.
+ *
+ * @return string HTML output.
  */
 function bp_nouveau_member_description( $user_id = 0 ) {
-	if ( empty( $user_id ) ) {
+	if ( ! $user_id ) {
 		$user_id = bp_loggedin_user_id();
 
 		if ( bp_displayed_user_id() ) {
@@ -729,6 +730,7 @@ function bp_nouveau_member_description( $user_id = 0 ) {
 		}
 	}
 
+	// @todo This hack is too brittle.
 	add_filter( 'the_author_description', 'make_clickable', 9 );
 	add_filter( 'the_author_description', 'wpautop'           );
 	add_filter( 'the_author_description', 'wptexturize'       );
@@ -747,10 +749,11 @@ function bp_nouveau_member_description( $user_id = 0 ) {
 }
 
 /**
- * Display the Edit profile link (temporary)
- * @todo  replace with Ajax feature
+ * Display the Edit profile link (temporary).
  *
  * @since 1.0.0
+ *
+ * @todo replace with Ajax feature
  *
  * @return string HTML Output
  */
@@ -780,6 +783,7 @@ function bp_nouveau_member_description_edit_link() {
 
 		return sprintf( '<a href="%1$s">%2$s</a>', esc_url( $link ), esc_html__( 'Edit your bio', 'buddypress' ) );
 	}
+
 
 /** WP Profile tags **********************************************************/
 
@@ -837,13 +841,11 @@ function bp_nouveau_wp_profile_hooks( $type = 'before' ) {
  */
 function bp_nouveau_has_wp_profile_fields() {
 	$user_id = bp_displayed_user_id();
-
-	if ( empty( $user_id ) ) {
+	if ( ! $user_id ) {
 		return false;
 	}
 
 	$user = get_userdata( $user_id );
-
 	if ( ! $user ) {
 		return false;
 	}
@@ -859,7 +861,7 @@ function bp_nouveau_has_wp_profile_fields() {
 		$user_profile_fields[] = (object) array( 'id' => 'wp_' . $key, 'label' => $field, 'data' => $user->{$key} );
 	}
 
-	if ( empty( $user_profile_fields ) ) {
+	if ( ! $user_profile_fields ) {
 		return false;
 	}
 
@@ -909,7 +911,7 @@ function bp_nouveau_wp_profile_field() {
  * @since 1.0.0
  */
 function bp_nouveau_wp_profile_field_id() {
-	echo bp_nouveau_get_wp_profile_field_id();
+	echo esc_attr( bp_nouveau_get_wp_profile_field_id() );
 }
 	/**
 	 * Get the WP profile field ID.
@@ -920,8 +922,7 @@ function bp_nouveau_wp_profile_field_id() {
 	 */
 	function bp_nouveau_get_wp_profile_field_id() {
 		$field = bp_nouveau()->members->wp_profile_current;
-
-		return esc_attr( apply_filters( 'bp_nouveau_get_wp_profile_field_id', $field->id ) );
+		return apply_filters( 'bp_nouveau_get_wp_profile_field_id', $field->id );
 	}
 
 /**
@@ -930,7 +931,7 @@ function bp_nouveau_wp_profile_field_id() {
  * @since 1.0.0
  */
 function bp_nouveau_wp_profile_field_label() {
-	echo bp_nouveau_get_wp_profile_field_label();
+	echo esc_html( bp_nouveau_get_wp_profile_field_label() );
 }
 
 	/**
@@ -942,8 +943,7 @@ function bp_nouveau_wp_profile_field_label() {
 	 */
 	function bp_nouveau_get_wp_profile_field_label() {
 		$field = bp_nouveau()->members->wp_profile_current;
-
-		return esc_html( apply_filters( 'bp_nouveau_get_wp_profile_field_label', $field->label ) );
+		return apply_filters( 'bp_nouveau_get_wp_profile_field_label', $field->label );
 	}
 
 /**
@@ -952,7 +952,18 @@ function bp_nouveau_wp_profile_field_label() {
  * @since 1.0.0
  */
 function bp_nouveau_wp_profile_field_data() {
-	echo bp_nouveau_get_wp_profile_field_data();
+	$data = bp_nouveau_get_wp_profile_field_data();
+	$data = make_clickable( $data );
+
+	return wp_kses(
+		/**
+		 * Filters a WP profile field value.
+		 *
+		 * @param string $data The profile field value.
+		 */
+		apply_filters( 'bp_nouveau_get_wp_profile_field_data', $data ),
+		array( 'a' => array( 'href' => true, 'rel' => true ) )
+	);
 }
 
 	/**
@@ -964,8 +975,5 @@ function bp_nouveau_wp_profile_field_data() {
 	 */
 	function bp_nouveau_get_wp_profile_field_data() {
 		$field = bp_nouveau()->members->wp_profile_current;
-
-		$data = make_clickable( $field->data );
-
-		return wp_kses( apply_filters( 'bp_nouveau_get_wp_profile_field_data', $data ), array( 'a' => array( 'href' => true, 'rel' => true ) ) );
+		return $field->data;
 	}

--- a/bp-templates/bp-nouveau/includes/members/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/members/template-tags.php
@@ -487,7 +487,7 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 		}
 
 		// It's the first entry of the loop, so build the Group and sort it
-		if ( ! isset( bp_nouveau()->members->member_buttons ) || false === is_a( bp_nouveau()->members->member_buttons, 'BP_Buttons_Group' ) ) {
+		if ( ! isset( bp_nouveau()->members->member_buttons ) || ! is_a( bp_nouveau()->members->member_buttons, 'BP_Buttons_Group' ) ) {
 			$sort = true;
 			bp_nouveau()->members->member_buttons = new BP_Buttons_Group( $buttons_group );
 

--- a/bp-templates/bp-nouveau/includes/messages/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/messages/template-tags.php
@@ -11,24 +11,27 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Fire specific hooks into the private messages template
+ * Fire specific hooks into the private messages template.
  *
  * @since 1.0.0
+ * @since 1.0.0 (BuddyPress) for the 'composent_content' (after), 'thread_header_actions', 'meta',
+ *                           'content', 'thread_content', 'thread_list', 'reply_box' suffixes
+ * @since 1.1.0 (BuddyPress) for the 'compose_content' (before), 'thread_reply' suffixes
  *
- * @param string $when    'before' or 'after'
- * @param string $suffix  Use it to add terms at the end of the hook name
+ * @param string $when   Either 'before' or 'after'.
+ * @param string $suffix Use it to add terms at the end of the hook name.
  */
 function bp_nouveau_messages_hook( $when = '', $suffix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( $when ) {
 		$hook[] = $when;
 	}
 
 	// It's a message hook
 	$hook[] = 'message';
 
-	if ( ! empty( $suffix ) ) {
+	if ( $suffix ) {
 		if ( 'compose_content' === $suffix ) {
 			$hook[2] = 'messages';
 		}
@@ -36,11 +39,6 @@ function bp_nouveau_messages_hook( $when = '', $suffix = '' ) {
 		$hook[] = $suffix;
 	}
 
-	/**
-	 * @since 1.0.0 (BuddyPress) for the 'composent_content' (after), 'thread_header_actions', 'meta',
-	 *                           'content', 'thread_content', 'thread_list', 'reply_box' suffixes
-	 * @since 1.1.0 (BuddyPress) for the 'compose_content' (before), 'thread_reply' suffixes
-	 */
 	bp_nouveau_hook( $hook );
 }
 
@@ -48,8 +46,6 @@ function bp_nouveau_messages_hook( $when = '', $suffix = '' ) {
  * Load the new Messages User Interface
  *
  * @since 1.0.0
- *
- * @return string HTML Output
  */
 function bp_nouveau_messages_member_interface() {
 	/**

--- a/bp-templates/bp-nouveau/includes/notifications/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/notifications/template-tags.php
@@ -14,8 +14,6 @@ defined( 'ABSPATH' ) || exit;
  * Display the notifications filter options.
  *
  * @since 1.0.0
- *
- * @return string HTML output.
  */
 function bp_nouveau_notifications_filters() {
 	echo bp_nouveau_get_notifications_filters();
@@ -42,15 +40,15 @@ function bp_nouveau_notifications_filters() {
 				continue;
 			}
 
-			$output .= sprintf( '<option value="%1$s"%2$s>%3$s</option>',
-				sanitize_key( $filter['id'] ),
+			$output .= sprintf( '<option value="%1$s" %2$s>%3$s</option>',
+				esc_attr( sanitize_key( $filter['id'] ) ),
 				selected( $selected, $filter['id'], false ),
 				esc_html( $filter['label'] )
 			) . "\n";
 		}
 
-		if ( ! empty( $output ) ) {
-			$output = sprintf( '<option value="%1$s"%2$s>%3$s</option>',
+		if ( $output ) {
+			$output = sprintf( '<option value="%1$s" %2$s>%3$s</option>',
 				0,
 				selected( $selected, 0, false ),
 				esc_html__( '&mdash; Everything &mdash;', 'buddypress' )
@@ -58,12 +56,12 @@ function bp_nouveau_notifications_filters() {
 		}
 
 		/**
-		 * Filter here to edit the options output.
+		 * Filter to edit the options output.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param  string $output  The options output.
-		 * @param  array  $filters The sorted notifications filters.
+		 * @param string $output  The options output.
+		 * @param array  $filters The sorted notifications filters.
 		 */
 		return apply_filters( 'bp_nouveau_get_notifications_filters', $output, $filters );
 	}
@@ -72,8 +70,6 @@ function bp_nouveau_notifications_filters() {
  * Outputs the order action links.
  *
  * @since 1.0.0
- *
- * @return string HTML output.
  */
 function bp_nouveau_notifications_sort_order_links() {
 	if ( 'unread' === bp_current_action() ) {
@@ -98,8 +94,6 @@ function bp_nouveau_notifications_sort_order_links() {
  * Output the dropdown for bulk management of notifications.
  *
  * @since 1.0.0
- *
- * @return string HTML output.
  */
 function bp_nouveau_notifications_bulk_management_dropdown() {
 ?>

--- a/bp-templates/bp-nouveau/includes/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/template-tags.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @param array $pieces The list of terms of the hook to join.
  */
 function bp_nouveau_hook( $pieces = array() ) {
-	if ( empty( $pieces ) ) {
+	if ( ! $pieces ) {
 		return;
 	}
 
@@ -40,15 +40,10 @@ function bp_nouveau_hook( $pieces = array() ) {
  * @param string The suffix of the hook.
  */
 function bp_nouveau_plugin_hook( $suffix = '' ) {
-	if ( empty( $suffix ) ) {
+	if ( ! $suffix ) {
 		return;
 	}
 
-	/**
-	 * Fires and displays content/title for plugins using the BP_Group_Extension.
-	 *
-	 * @since 1.0.0 (BuddyPress)
-	 */
 	bp_nouveau_hook( array(
 		'bp',
 		'template',
@@ -67,13 +62,10 @@ function bp_nouveau_plugin_hook( $suffix = '' ) {
  * @param string The suffix of the hook.
  */
 function bp_nouveau_friend_hook( $suffix = '' ) {
-	if ( empty( $suffix ) ) {
+	if ( ! $suffix ) {
 		return;
 	}
 
-	/**
-	 * @since 1.1.0 (BuddyPress)
-	 */
 	bp_nouveau_hook( array(
 		'bp',
 		'friend',
@@ -157,8 +149,6 @@ function bp_nouveau_has_dismiss_button() {
  * Ouptut the dismiss type.
  *
  * @since 1.0.0
- *
- * @return string The dismiss type.
  */
 function bp_nouveau_dismiss_button_type() {
 	$bp_nouveau = bp_nouveau();
@@ -194,11 +184,14 @@ function bp_nouveau_template_message() {
 
 		if ( ! empty( $bp_nouveau->user_feedback['message'] ) ) {
 			$user_feedback = $bp_nouveau->user_feedback['message'];
+
+			// @TODO: why is this treated differently?
 			foreach ( array( 'wp_kses_data', 'wp_unslash', 'wptexturize', 'convert_smilies', 'convert_chars' ) as $filter ) {
 				$user_feedback = call_user_func( $filter, $user_feedback );
 			}
 
 			return '<p>' . $user_feedback . '</p>';
+
 		} elseif ( ! empty( $bp_nouveau->template_message['message'] ) ) {
 			/**
 			 * Filters the 'template_notices' feedback message content.
@@ -261,8 +254,9 @@ function bp_nouveau_template_notices() {
  *
  * @since 1.0.0
  *
- * @param  string  $feedback_id The ID of the message to display
- * @return string  HTML Output.
+ * @param  string $feedback_id The ID of the message to display
+ *
+ * @return string HTML Output.
  */
 function bp_nouveau_user_feedback( $feedback_id = '' ) {
 	if ( ! isset( $feedback_id ) ) {
@@ -282,14 +276,16 @@ function bp_nouveau_user_feedback( $feedback_id = '' ) {
 
 	$bp_nouveau->user_feedback = $feedback;
 
-	/**
-	 * Filter here if you wish to use a different templates than the notice one.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string path to your template part.
-	 */
-	bp_get_template_part( apply_filters( 'bp_nouveau_user_feedback_template', 'common/notices/template-notices' ) );
+	bp_get_template_part(
+		/**
+		 * Filter here if you wish to use a different templates than the notice one.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string path to your template part.
+		 */
+		apply_filters( 'bp_nouveau_user_feedback_template', 'common/notices/template-notices' )
+	);
 
 	if ( ! empty( $feedback['after'] ) ) {
 		do_action( $feedback['after'] );
@@ -342,11 +338,14 @@ function bp_nouveau_after_loop() {
 /**
  * Pagination for loops
  *
+ * @param string $position
+ *
  * @since 1.0.0
  */
-function bp_nouveau_pagination( $position = null ) {
+function bp_nouveau_pagination( $position ) {
 	$component = bp_current_component();
 
+	// @TODO: How is this ever going to occur?
 	if ( ! bp_is_active( $component ) ) {
 		return;
 	}
@@ -356,6 +355,7 @@ function bp_nouveau_pagination( $position = null ) {
 
 	if ( bp_is_user() ) {
 		$screen = 'user';
+
 	} elseif ( bp_is_group() ) {
 		$screen          = 'group';
 		$pagination_type = bp_current_action();
@@ -366,23 +366,19 @@ function bp_nouveau_pagination( $position = null ) {
 	}
 
 	switch( $pagination_type ) {
-
 		case 'blogs' :
-
 			$pag_count   = bp_get_blogs_pagination_count();
 			$pag_links   = bp_get_blogs_pagination_links();
 			$top_hook    = 'bp_before_directory_blogs_list';
 			$bottom_hook = 'bp_after_directory_blogs_list';
 			$page_arg    = $GLOBALS['blogs_template']->pag_arg;
-
 		break;
 
 		case 'members'        :
 		case 'friends'        :
 		case 'manage-members' :
-
-			$pag_count   = bp_get_members_pagination_count();
-			$pag_links   = bp_get_members_pagination_links();
+			$pag_count = bp_get_members_pagination_count();
+			$pag_links = bp_get_members_pagination_links();
 
 			// Groups single items are not using these hooks
 			if ( ! bp_is_group() ) {
@@ -390,38 +386,31 @@ function bp_nouveau_pagination( $position = null ) {
 				$bottom_hook = 'bp_after_directory_members_list';
 			}
 
-			$page_arg    = $GLOBALS['members_template']->pag_arg;
-
+			$page_arg = $GLOBALS['members_template']->pag_arg;
 		break;
 
 		case 'groups' :
-
 			$pag_count   = bp_get_groups_pagination_count();
 			$pag_links   = bp_get_groups_pagination_links();
 			$top_hook    = 'bp_before_directory_groups_list';
 			$bottom_hook = 'bp_after_directory_groups_list';
 			$page_arg    = $GLOBALS['groups_template']->pag_arg;
-
 		break;
 
 		case 'notifications' :
-
 			$pag_count   = bp_get_notifications_pagination_count();
 			$pag_links   = bp_get_notifications_pagination_links();
 			$top_hook    = '';
 			$bottom_hook = '';
 			$page_arg    = buddypress()->notifications->query_loop->pag_arg;
-
 		break;
 
 		case 'membership-requests' :
-
 			$pag_count   = bp_get_group_requests_pagination_count();
 			$pag_links   = bp_get_group_requests_pagination_links();
 			$top_hook    = '';
 			$bottom_hook = '';
 			$page_arg    = $GLOBALS['requests_template']->pag_arg;
-
 		break;
 	}
 
@@ -436,25 +425,26 @@ function bp_nouveau_pagination( $position = null ) {
 		 * @since 1.1.0
 		 */
 		do_action( $bottom_hook );
-	};?>
+	};
+	?>
 
-	<div class="bp-pagination <?php echo sanitize_html_class( $position ); ?>" data-bp-pagination="<?php echo esc_attr( $page_arg ); ?>">
+	<div class="<?php echo esc_attr( 'bp-pagination ' . sanitize_html_class( $position ) ); ?>" data-bp-pagination="<?php echo esc_attr( $page_arg ); ?>">
 
 		<?php if ( $pag_count ) : ?>
-			<div class="pag-count <?php echo sanitize_html_class( $count_class ); ?>">
+			<div class="<?php echo esc_attr( 'pag-count ' . sanitize_html_class( $position ) ); ?>">
 
 				<p class="pag-data">
-					<?php echo $pag_count; ?>
+					<?php echo esc_html( $pag_count ); ?>
 				</p>
 
 			</div>
 		<?php endif; ?>
 
 		<?php if ( $pag_links ) : ?>
-			<div class="bp-pagination-links <?php echo sanitize_html_class( $links_class ); ?>">
+			<div class="<?php echo esc_attr( 'bp-pagination-links ' . sanitize_html_class( $position ) ); ?>">
 
 				<p class="pag-data">
-					<?php echo $pag_links; ?>
+					<?php echo wp_kses_post( $pag_links ); ?>
 				</p>
 
 			</div>
@@ -469,10 +459,7 @@ function bp_nouveau_pagination( $position = null ) {
 		 * @since 1.1.0 (BuddyPress)
 		 */
 		do_action( $top_hook );
-	};?>
-
-	<?php
-	return;
+	};
 }
 
 /**
@@ -480,10 +467,10 @@ function bp_nouveau_pagination( $position = null ) {
  *
  * @since 1.0.0
  *
- * @return string CSS classes
+ * @return string CSS class attributes (escaped).
  */
 function bp_nouveau_loop_classes() {
-	echo bp_nouveau_get_loop_classes();
+	echo esc_attr( bp_nouveau_get_loop_classes() );
 }
 
 	/**
@@ -496,17 +483,15 @@ function bp_nouveau_loop_classes() {
 	function bp_nouveau_get_loop_classes() {
 		$bp_nouveau = bp_nouveau();
 
-		/**
-		* @todo: this function could do with passing args so we can pass simple strings in  or array of strings
-		*/
+		// @todo: this function could do with passing args so we can pass simple strings in  or array of strings
 
 		// The $component is faked if it's the single group member loop
-		if ( !bp_is_directory() && ( bp_is_group() && 'members' === bp_current_action() ) ) :
-			$component  = 'members_group';
+		if ( ! bp_is_directory() && ( bp_is_group() && 'members' === bp_current_action() ) ) :
+			$component = 'members_group';
 		elseif ( ! bp_is_directory() && ( bp_is_user() && 'my-friends' === bp_current_action() ) ):
-			$component  = 'members_friends';
+			$component = 'members_friends';
 		else :
-			$component  = sanitize_key( bp_current_component() );
+			$component = sanitize_key( bp_current_component() );
 		endif;
 
 		$classes = array(
@@ -523,18 +508,23 @@ function bp_nouveau_loop_classes() {
 			'members' => true,
 			'groups'  => true,
 			'blogs'   => true,
-			// technically not a component but allows us to check
-			// the single group members loop as a seperate loop.
-			'members_group' => true,
+
+			/*
+			 * Technically not a component but allows us to check the single group members loop as a seperate loop.
+			 */
+			'members_group'   => true,
 			'members_friends' => true,
 		);
 
 		// Only the available components supports custom layouts.
 		if ( ! empty( $available_components[ $component ] ) && ( bp_is_directory() || bp_is_group() || bp_is_user() ) ) {
 			$customizer_option = sprintf( '%s_layout', $component );
-			$layout_prefs      = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );
+			$layout_prefs      = bp_nouveau_get_temporary_setting(
+				$customizer_option,
+				bp_nouveau_get_appearance_settings( $customizer_option )
+			);
 
-			if ( ! empty( $layout_prefs ) && (int) $layout_prefs > 1 ) {
+			if ( $layout_prefs && (int) $layout_prefs > 1 ) {
 				$grid_classes = bp_nouveau_customizer_grid_choices( 'classes' );
 
 				if ( isset( $grid_classes[ $layout_prefs ] ) ) {
@@ -550,7 +540,7 @@ function bp_nouveau_loop_classes() {
 		}
 
 		/**
-		 * Filter here to edit/add classes.
+		 * Filter to edit/add classes.
 		 *
 		 * NB: you can also directly add classes into the template parts.
 		 *
@@ -596,7 +586,14 @@ function bp_nouveau_loop_get_grid_columns() {
 		$columns = (int) $bp_nouveau->{$component}->loop_layout;
 	}
 
-	return apply_filters( 'bp_nouveau_loop_get_grid_columns', $columns );
+	/**
+	 * Filter number of columns for this grid.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $columns The number of columns.
+	 */
+	return (int) apply_filters( 'bp_nouveau_loop_get_grid_columns', $columns );
 }
 
 /**
@@ -623,6 +620,11 @@ function bp_dir_is_vert_layout() {
  * @return array The avatar arguments.
  */
 function bp_nouveau_avatar_args() {
+	/**
+	 * Filter arguments for full-size avatars.
+	 *
+	 * @param array $args
+	 */
 	return apply_filters( 'bp_nouveau_avatar_args',  array(
 		'type'   => 'full',
 		'width'  => bp_core_avatar_full_width(),
@@ -630,9 +632,10 @@ function bp_nouveau_avatar_args() {
 	) );
 }
 
+
 /** Template Tags for BuddyPress navigations **********************************/
 
-/**
+/*
  * This is the BP Nouveau Navigation Loop.
  *
  * It can be used by any object using the
@@ -640,7 +643,7 @@ function bp_nouveau_avatar_args() {
  */
 
 /**
- * Init the Navigation Loop and checks it has items.
+ * Init the Navigation Loop and check it has items.
  *
  * @since 1.0.0
  *
@@ -654,7 +657,8 @@ function bp_nouveau_avatar_args() {
  *     @type bool   $user_has_access         Used by the secondary member's & group's nav. Default true. Optional.
  *     @type bool   $show_for_displayed_user Used by the primary member's nav. Default true. Optional.
  * }
- * @return bool         True if the Nav contains items. False otherwise.
+ *
+ * @return bool True if the Nav contains items. False otherwise.
  */
 function bp_nouveau_has_nav( $args = array() ) {
 	$bp_nouveau = bp_nouveau();
@@ -710,6 +714,7 @@ function bp_nouveau_has_nav( $args = array() ) {
 				'parent_slug'     => bp_current_component(),
 				'user_has_access' => (bool) $n['user_has_access'],
 			) );
+
 		} else {
 			$args = array();
 
@@ -791,7 +796,7 @@ function bp_nouveau_nav_item() {
  * @since 1.0.0
  */
 function bp_nouveau_nav_id() {
-	echo bp_nouveau_get_nav_id();
+	echo esc_attr( bp_nouveau_get_nav_id() );
 }
 
 	/**
@@ -814,7 +819,7 @@ function bp_nouveau_nav_id() {
 		}
 
 		/**
-		 * Filter here to edit the ID attribute of the nav.
+		 * Filter to edit the ID attribute of the nav.
 		 *
 		 * @since 1.0.0
 		 *
@@ -822,7 +827,7 @@ function bp_nouveau_nav_id() {
 		 * @param object $nav_item The current nav item object.
 		 * @param string $value    The current nav in use (eg: 'directory', 'groups', 'personal', etc..).
 		 */
-		return esc_attr( apply_filters( 'bp_nouveau_get_nav_id', $id, $nav_item, $bp_nouveau->displayed_nav ) );
+		return apply_filters( 'bp_nouveau_get_nav_id', $id, $nav_item, $bp_nouveau->displayed_nav );
 	}
 
 /**
@@ -831,7 +836,7 @@ function bp_nouveau_nav_id() {
  * @since 1.0.0
  */
 function bp_nouveau_nav_classes() {
-	echo bp_nouveau_get_nav_classes();
+	echo esc_attr( bp_nouveau_get_nav_classes() );
 }
 
 	/**
@@ -839,7 +844,7 @@ function bp_nouveau_nav_classes() {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string the list of classes.
+	 * @return string List of classes.
 	 */
 	function bp_nouveau_get_nav_classes() {
 		$bp_nouveau = bp_nouveau();
@@ -876,7 +881,7 @@ function bp_nouveau_nav_classes() {
 		}
 
 		/**
-		 * Filter here to edit/add classes.
+		 * Filter to edit/add classes.
 		 *
 		 * NB: you can also directly add classes into the template parts.
 		 *
@@ -889,11 +894,11 @@ function bp_nouveau_nav_classes() {
 		 */
 		$classes_list = apply_filters( 'bp_nouveau_get_classes', join( ' ', $classes ), $classes, $nav_item, $bp_nouveau->displayed_nav );
 
-		if ( empty( $classes_list ) ) {
-			return;
+		if ( ! $classes_list ) {
+			return '';
 		}
 
-		return esc_attr( $classes_list );
+		return $classes_list;
 	}
 
 /**
@@ -902,7 +907,7 @@ function bp_nouveau_nav_classes() {
  * @since 1.0.0
  */
 function bp_nouveau_nav_scope() {
-	echo bp_nouveau_get_nav_scope();
+	echo bp_nouveau_get_nav_scope();  // Escaped by bp_get_form_field_attributes().
 }
 
 	/**
@@ -915,26 +920,28 @@ function bp_nouveau_nav_scope() {
 	function bp_nouveau_get_nav_scope() {
 		$bp_nouveau = bp_nouveau();
 		$nav_item   = $bp_nouveau->current_nav_item;
+		$scope      = array();
 
-		$scope = array();
 		if ( 'directory' === $bp_nouveau->displayed_nav ) {
 			$scope = array( 'data-bp-scope' => $nav_item->slug );
+
 		} elseif ( 'personal' === $bp_nouveau->displayed_nav && ! empty( $nav_item->secondary ) ) {
 			$scope = array( 'data-bp-user-scope' => $nav_item->slug );
+
 		} else {
 			/**
-			 * Filter here to add your own scope.
+			 * Filter to add your own scope.
 			 *
 			 * @since 1.0.0
 			 *
-			 * @param string $scope    An array containing the key and the value for your scope.
+			 * @param array $scope     Contains the key and the value for your scope.
 			 * @param object $nav_item The current nav item object.
 			 * @param string $value    The current nav in use (eg: 'directory', 'groups', 'personal', etc..).
 			 */
 			$scope = apply_filters( 'bp_nouveau_set_nav_scope', $scope, $nav_item, $bp_nouveau->displayed_nav );
 		}
 
-		if ( empty( $scope ) ) {
+		if ( ! $scope ) {
 			return;
 		}
 
@@ -942,20 +949,20 @@ function bp_nouveau_nav_scope() {
 	}
 
 /**
- * Displays the nav item link.
+ * Displays the nav item URL.
  *
  * @since 1.0.0
  */
 function bp_nouveau_nav_link() {
-	echo bp_nouveau_get_nav_link();
+	echo esc_url( bp_nouveau_get_nav_link() );
 }
 
 	/**
-	 * Retrieve the link for the current nav item.
+	 * Retrieve the URL for the current nav item.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string The link for the nav item.
+	 * @return string The URL for the nav item.
 	 */
 	function bp_nouveau_get_nav_link() {
 		$bp_nouveau = bp_nouveau();
@@ -975,15 +982,15 @@ function bp_nouveau_nav_link() {
 		}
 
 		/**
-		 * Filter here to edit the link of the nav.
+		 * Filter to edit the URL of the nav item.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $link     The link for the nav item.
+		 * @param string $link     The URL for the nav item.
 		 * @param object $nav_item The current nav item object.
 		 * @param string $value    The current nav in use (eg: 'directory', 'groups', 'personal', etc..).
 		 */
-		return esc_url( apply_filters( 'bp_nouveau_get_nav_link', $link, $nav_item, $bp_nouveau->displayed_nav ) );
+		return apply_filters( 'bp_nouveau_get_nav_link', $link, $nav_item, $bp_nouveau->displayed_nav );
 	}
 
 /**
@@ -992,7 +999,7 @@ function bp_nouveau_nav_link() {
  * @since 1.0.0
  */
 function bp_nouveau_nav_link_id() {
-	echo bp_nouveau_get_nav_link_id();
+	echo esc_attr( bp_nouveau_get_nav_link_id() );
 }
 
 	/**
@@ -1018,7 +1025,7 @@ function bp_nouveau_nav_link_id() {
 		}
 
 		/**
-		 * Filter here to edit the link id attribute of the nav.
+		 * Filter to edit the link id attribute of the nav.
 		 *
 		 * @since 1.0.0
 		 *
@@ -1026,7 +1033,7 @@ function bp_nouveau_nav_link_id() {
 		 * @param object $nav_item The current nav item object.
 		 * @param string $value    The current nav in use (eg: 'directory', 'groups', 'personal', etc..).
 		 */
-		return esc_attr( apply_filters( 'bp_nouveau_get_nav_link_id', $link_id, $nav_item, $bp_nouveau->displayed_nav ) );
+		return apply_filters( 'bp_nouveau_get_nav_link_id', $link_id, $nav_item, $bp_nouveau->displayed_nav );
 	}
 
 /**
@@ -1035,7 +1042,7 @@ function bp_nouveau_nav_link_id() {
  * @since 1.0.0
  */
 function bp_nouveau_nav_link_title() {
-	echo bp_nouveau_get_nav_link_title();
+	echo esc_attr( bp_nouveau_get_nav_link_title() );
 }
 
 	/**
@@ -1048,16 +1055,21 @@ function bp_nouveau_nav_link_title() {
 	function bp_nouveau_get_nav_link_title() {
 		$bp_nouveau = bp_nouveau();
 		$nav_item   = $bp_nouveau->current_nav_item;
+		$title      = '';
 
-		$title = '';
 		if ( 'directory' === $bp_nouveau->displayed_nav && ! empty( $nav_item->title ) ) {
 			$title = $nav_item->title;
-		} elseif ( ( 'groups' === $bp_nouveau->displayed_nav || 'personal' === $bp_nouveau->displayed_nav ) && ! empty( $nav_item->name ) ) {
+
+		} elseif (
+			( 'groups' === $bp_nouveau->displayed_nav || 'personal' === $bp_nouveau->displayed_nav )
+			&&
+			! empty( $nav_item->name )
+		) {
 			$title = $nav_item->name;
 		}
 
 		/**
-		 * Filter here to edit the link title attribute of the nav.
+		 * Filter to edit the link title attribute of the nav.
 		 *
 		 * @since 1.0.0
 		 *
@@ -1065,7 +1077,7 @@ function bp_nouveau_nav_link_title() {
 		 * @param object $nav_item The current nav item object.
 		 * @param string $value    The current nav in use (eg: 'directory', 'groups', 'personal', etc..).
 		 */
-		return esc_attr( apply_filters( 'bp_nouveau_get_nav_link_title', $title, $nav_item, $bp_nouveau->displayed_nav ) );
+		return apply_filters( 'bp_nouveau_get_nav_link_title', $title, $nav_item, $bp_nouveau->displayed_nav );
 	}
 
 /**
@@ -1074,7 +1086,7 @@ function bp_nouveau_nav_link_title() {
  * @since 1.0.0
  */
 function bp_nouveau_nav_link_text() {
-	echo bp_nouveau_get_nav_link_text();
+	echo esc_html( bp_nouveau_get_nav_link_text() );
 }
 
 	/**
@@ -1087,16 +1099,21 @@ function bp_nouveau_nav_link_text() {
 	function bp_nouveau_get_nav_link_text() {
 		$bp_nouveau = bp_nouveau();
 		$nav_item   = $bp_nouveau->current_nav_item;
+		$link_text  = '';
 
-		$link_text = '';
 		if ( 'directory' === $bp_nouveau->displayed_nav && ! empty( $nav_item->text ) ) {
 			$link_text = $nav_item->text;
-		} elseif ( ( 'groups' === $bp_nouveau->displayed_nav || 'personal' === $bp_nouveau->displayed_nav ) && ! empty( $nav_item->name ) ) {
+
+		} elseif (
+			( 'groups' === $bp_nouveau->displayed_nav || 'personal' === $bp_nouveau->displayed_nav )
+			&&
+			! empty( $nav_item->name )
+		) {
 			$link_text = _bp_strip_spans_from_title( $nav_item->name );
 		}
 
 		/**
-		 * Filter here to edit the html text of the nav.
+		 * Filter to edit the html text of the nav.
 		 *
 		 * @since 1.0.0
 		 *
@@ -1104,13 +1121,15 @@ function bp_nouveau_nav_link_text() {
 		 * @param object $nav_item  The current nav item object.
 		 * @param string $value     The current nav in use (eg: 'directory', 'groups', 'personal', etc..).
 		 */
-		return esc_html( apply_filters( 'bp_nouveau_get_nav_link_text', $link_text, $nav_item, $bp_nouveau->displayed_nav ) );
+		return apply_filters( 'bp_nouveau_get_nav_link_text', $link_text, $nav_item, $bp_nouveau->displayed_nav );
 	}
 
 /**
  * Checks if the nav item has a count attribute.
  *
  * @since 1.0.0
+ *
+ * @return bool
  */
 function bp_nouveau_nav_has_count() {
 	$bp_nouveau = bp_nouveau();
@@ -1126,7 +1145,7 @@ function bp_nouveau_nav_has_count() {
 	}
 
 	/**
-	 * Filter here to edit whether the nav has a count attribute.
+	 * Filter to edit whether the nav has a count attribute.
 	 *
 	 * @since 1.0.0
 	 *
@@ -1134,7 +1153,7 @@ function bp_nouveau_nav_has_count() {
 	 * @param object $nav_item  The current nav item object.
 	 * @param string $value     The current nav in use (eg: 'directory', 'groups', 'personal', etc..).
 	 */
-	return apply_filters( 'bp_nouveau_nav_has_count', false !== $count, $nav_item, $bp_nouveau->displayed_nav );
+	return (bool) apply_filters( 'bp_nouveau_nav_has_count', false !== $count, $nav_item, $bp_nouveau->displayed_nav );
 }
 
 /**
@@ -1143,7 +1162,7 @@ function bp_nouveau_nav_has_count() {
  * @since 1.0.0
  */
 function bp_nouveau_nav_count() {
-	echo bp_nouveau_get_nav_count();
+	echo esc_html( number_format_i18n( bp_nouveau_get_nav_count() ) );
 }
 
 	/**
@@ -1151,21 +1170,20 @@ function bp_nouveau_nav_count() {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string The count attribute for the nav item.
+	 * @return int The count attribute for the nav item.
 	 */
 	function bp_nouveau_get_nav_count() {
 		$bp_nouveau = bp_nouveau();
 		$nav_item   = $bp_nouveau->current_nav_item;
+		$count      = 0;
 
-		$count = 0;
 		if ( 'directory' === $bp_nouveau->displayed_nav ) {
-			$count = $nav_item->count;
-		} elseif ( 'groups' === $bp_nouveau->displayed_nav && 'members' === $nav_item->slug ) {
-			$count = number_format( groups_get_current_group()->total_member_count );
+			$count = (int) $nav_item->count;
 
-		/**
-		 * imho BuddyPress shouldn't add html tags inside Nav attributes...
-		 */
+		} elseif ( 'groups' === $bp_nouveau->displayed_nav && 'members' === $nav_item->slug ) {
+			$count = groups_get_current_group()->total_member_count;
+
+		// @todo imho BuddyPress shouldn't add html tags inside Nav attributes...
 		} elseif ( 'personal' === $bp_nouveau->displayed_nav && ! empty( $nav_item->primary ) ) {
 			$span = strpos( $nav_item->name, '<span' );
 
@@ -1178,15 +1196,15 @@ function bp_nouveau_nav_count() {
 		}
 
 		/**
-		 * Filter here to edit the count attribute for the nav item.
+		 * Filter to edit the count attribute for the nav item.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $count    The count attribute for the nav item.
+		 * @param int $count    The count attribute for the nav item.
 		 * @param object $nav_item The current nav item object.
 		 * @param string $value    The current nav in use (eg: 'directory', 'groups', 'personal', etc..).
 		 */
-		return esc_attr( apply_filters( 'bp_nouveau_get_nav_count', $count, $nav_item, $bp_nouveau->displayed_nav ) );
+		return (int) apply_filters( 'bp_nouveau_get_nav_count', $count, $nav_item, $bp_nouveau->displayed_nav );
 	}
 
 /** Template tags specific to the Directory navs ******************************/
@@ -1197,27 +1215,28 @@ function bp_nouveau_nav_count() {
  * @since 1.0.0
  */
 function bp_nouveau_directory_type_navs_class() {
-	echo bp_nouveau_get_directory_type_navs_class();
+	echo esc_attr( bp_nouveau_get_directory_type_navs_class() );
 }
 
 	/**
 	 * Provides default nav wrapper classes.
+	 *
 	 * Gets the directory component nav class.
-	 * gets user selection Customizer options
+	 * Gets user selection Customizer options.
 	 *
 	 * @since 1.0.0
-	 * @return string classes
+	 *
+	 * @return string
 	 */
 	function bp_nouveau_get_directory_type_navs_class() {
+		$component  = sanitize_key( bp_current_component() );
+		$customizer_option = sprintf( '%s_dir_tabs', $component );
+		$nav_style  = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );
+		$tab_style = '';
 
-			$component  = sanitize_key( bp_current_component() );
-			$customizer_option = sprintf( '%s_dir_tabs', $component );
-			$nav_style  = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );
-			$tab_style = '';
-
-			if ( 1 === $nav_style ) {
-				$tab_style = bp_current_component() . '-nav-tabs';
-			}
+		if ( 1 === $nav_style ) {
+			$tab_style = bp_current_component() . '-nav-tabs';
+		}
 
 		$nav_wrapper_classes = array(
 			sprintf( '%s-type-navs', bp_current_component() ),
@@ -1228,13 +1247,13 @@ function bp_nouveau_directory_type_navs_class() {
 		);
 
 		/**
-		 * Filter here to edit/add classes.
+		 * Filter to edit/add classes.
 		 *
 		 * NB: you can also directly add classes to the class attr.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param array  $nav_wrapper_classes  The list of classes.
+		 * @param array $nav_wrapper_classes The list of classes.
 		 */
 		$nav_wrapper_classes = (array) apply_filters( 'bp_nouveau_get_directory_type_navs_class', $nav_wrapper_classes );
 
@@ -1247,7 +1266,7 @@ function bp_nouveau_directory_type_navs_class() {
  * @since 1.0.0
  */
 function bp_nouveau_directory_list_class() {
-	echo bp_nouveau_get_directory_list_class();
+	echo esc_attr( bp_nouveau_get_directory_list_class() );
 }
 
 	/**
@@ -1256,9 +1275,7 @@ function bp_nouveau_directory_list_class() {
 	 * @since 1.0.0
 	 */
 	function bp_nouveau_get_directory_list_class() {
-		$class = sprintf( '%s-nav', bp_current_component() );
-
-		return sanitize_html_class( $class );
+		return sanitize_html_class( sprintf( '%s-nav', bp_current_component() ) );
 	}
 
 /**
@@ -1267,72 +1284,80 @@ function bp_nouveau_directory_list_class() {
  * @since 1.0.0
  */
 function bp_nouveau_directory_nav_object() {
-	echo bp_nouveau_get_directory_nav_object();
+	$obj = bp_nouveau_get_directory_nav_object();
+
+	if ( ! is_null( $obj ) ) {
+		echo esc_attr( $obj );
+	}
 }
 
 	/**
 	 * Gets the directory nav item object.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @return unknown @todo what is this?
 	 */
 	function bp_nouveau_get_directory_nav_object() {
 		$nav_item = bp_nouveau()->current_nav_item;
 
 		if ( ! $nav_item->component ) {
-			return;
+			return null;
 		}
 
-		return esc_attr( $nav_item->component );
+		return $nav_item->component;
 	}
+
 
 /** Template tags for the single item navs ***********************************/
 
 /**
- * Output main BuddyPress container classes
+ * Output main BuddyPress container classes.
  *
  * @since 1.0.0
  *
  * @return string CSS classes
  */
-function bp_nouveau_buddypress_classes() {
-	echo bp_nouveau_get_buddypress_classes();
+function bp_nouveau_container_classes() {
+	echo esc_attr( bp_nouveau_get_container_classes() );
 }
 
 	/**
-	 * Returns the main BuddyPress container classes
+	 * Returns the main BuddyPress container classes.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return string CSS classes
 	 */
-	function bp_nouveau_get_buddypress_classes() {
-		$classes    = array( 'buddypress-wrap' );
-		$component  = bp_current_component();
-		$bp_nouveau = bp_nouveau();
+	function bp_nouveau_get_container_classes() {
+		$classes           = array( 'buddypress-wrap' );
+		$component         = bp_current_component();
+		$bp_nouveau        = bp_nouveau();
 		$member_type_class = '';
 
 		if ( bp_is_user() ) {
 			$customizer_option = 'user_nav_display';
 			$component         = 'members';
-			$user_type = bp_get_member_type( bp_displayed_user_id() );
+			$user_type         = bp_get_member_type( bp_displayed_user_id() );
 			$member_type_class = ( $user_type )? $user_type : '';
-
 
 		} elseif ( bp_is_group() ) {
 			$customizer_option = 'group_nav_display';
 
 		} elseif ( bp_is_directory() ) {
-
 			switch ( $component ) {
 				case 'activity':
 					$customizer_option = 'activity_dir_layout';
 					break;
+
 				case 'members':
 					$customizer_option = 'members_dir_layout';
 					break;
+
 				case 'groups':
 					$customizer_option = 'groups_dir_layout';
 					break;
+
 				case 'blogs':
 					$customizer_option = 'sites_dir_layout';
 					break;
@@ -1351,27 +1376,28 @@ function bp_nouveau_buddypress_classes() {
 		}
 
 		// Provide a class token to acknowledge additional extended profile fields added to default account reg screen
-		if ( 'register' === bp_current_component() && bp_is_active( 'xprofile' ) && bp_nouveau_base_account_has_xprofile() ){
+		if ( 'register' === bp_current_component() && bp_is_active( 'xprofile' ) && bp_nouveau_base_account_has_xprofile()) {
 			$classes[] = 'extended-default-reg';
 		}
 
-		// Add classes according to site owners preferences. these are options set via Customizer
+		// Add classes according to site owners preferences. These are options set via Customizer.
 
 		// These are general site wide Cust options falling outside component checks
-		if ( $general_settings = bp_nouveau_get_temporary_setting( 'avatar_style', bp_nouveau_get_appearance_settings( 'avatar_style' ) ) ) {
+		$general_settings = bp_nouveau_get_temporary_setting( 'avatar_style', bp_nouveau_get_appearance_settings( 'avatar_style' ) );
+		if ( $general_settings ) {
 			$classes[] = 'round-avatars';
 		}
 
 		// Set via earlier switch for component check to provide correct option key.
-		if ( ! empty( $customizer_option ) ) {
+		if ( $customizer_option ) {
 			$layout_prefs  = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );
 
-			if ( ! empty( $layout_prefs ) && (int) $layout_prefs === 1 && ( bp_is_user() || bp_is_group() ) ) {
+			if ( $layout_prefs && (int) $layout_prefs === 1 && ( bp_is_user() || bp_is_group() ) ) {
 				$classes[] = 'bp-single-vert-nav';
 				$classes[] = 'bp-vertical-navs';
 			}
 
-			if ( ! empty( $layout_prefs ) && bp_is_directory() ) {
+			if ( $layout_prefs && bp_is_directory() ) {
 				$classes[] = 'bp-dir-vert-nav';
 				$classes[] = 'bp-vertical-navs';
 				$bp_nouveau->{$component}->directory_vertical_layout = $layout_prefs;
@@ -1380,7 +1406,7 @@ function bp_nouveau_buddypress_classes() {
 
 		$class = array_map( 'sanitize_html_class', $classes );
 
-		return apply_filters( 'bp_nouveau_get_buddypress_classes', join( ' ', $class ), $classes );
+		return apply_filters( 'bp_nouveau_get_container_classes', join( ' ', $class ), $classes );
 	}
 
 /**
@@ -1391,7 +1417,7 @@ function bp_nouveau_buddypress_classes() {
  * @return string CSS classes
  */
 function bp_nouveau_single_item_nav_classes() {
-	echo bp_nouveau_get_single_item_nav_classes();
+	echo esc_attr( bp_nouveau_get_single_item_nav_classes() );
 }
 
 	/**
@@ -1410,6 +1436,7 @@ function bp_nouveau_single_item_nav_classes() {
 		// this is a temp workaround but differs from earlier dir approach- bad!
 		if ( bp_is_group() ) {
 			$nav_tabs = bp_nouveau_get_temporary_setting( 'group_nav_tabs', bp_nouveau_get_appearance_settings( 'group_nav_tabs' ) );
+
 		} elseif ( bp_is_user() ) {
 			$nav_tabs = bp_nouveau_get_temporary_setting( 'user_nav_tabs', bp_nouveau_get_appearance_settings( 'user_nav_tabs' ) );
 		}
@@ -1429,9 +1456,9 @@ function bp_nouveau_single_item_nav_classes() {
 
 		$customizer_option = ( bp_is_user() )? 'user_nav_display' : 'group_nav_display';
 
-		$layout_prefs  = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );
+		$layout_prefs = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );
 
-		// Set the global for a later use - this is moved from the `bp_nouveau_get_buddypress_classes()
+		// Set the global for a later use - this is moved from the `bp_nouveau_get_container_classes()
 		// But was set as a check for this array class addition.
 		$bp_nouveau->{$component}->single_primary_nav_layout = $layout_prefs;
 
@@ -1440,7 +1467,6 @@ function bp_nouveau_single_item_nav_classes() {
 		}
 
 		$classes[] = $menu_type;
-
 		$class = array_map( 'sanitize_html_class', $classes );
 
 		return apply_filters( 'bp_nouveau_get_single_item_nav_classes', join( ' ', $class ), $classes );
@@ -1472,11 +1498,12 @@ function bp_nouveau_get_search_primary_object( $object = '' ) {
 }
 
 /**
- * Get The list of search objects (Primary + secondary)
+ * Get The list of search objects (primary + secondary).
  *
  * @since 1.0.0
  *
- * @param  array $objects The list of objects. Optionnal.
+ * @param  array $objects The list of objects. Optional.
+ *
  * @return array The list of objects.
  */
 function bp_nouveau_get_search_objects( $objects = array() ) {
@@ -1505,37 +1532,12 @@ function bp_nouveau_get_search_objects( $objects = array() ) {
  * Output the search form container classes.
  *
  * @since 1.0.0
- *
- * @return string CSS classes.
  */
 function bp_nouveau_search_container_class() {
 	$objects = bp_nouveau_get_search_objects();
+	$class   = join( '-search ', array_map( 'sanitize_html_class', $objects ) ) . '-search';
 
-	echo join( '-search ', array_map( 'sanitize_html_class', $objects ) ) . '-search';
-}
-
-/**
- * Output the search form data-bp attribute.
- *
- * @since 1.0.0
- *
- * @param  string $attr The data-bp attribute.
- * @return string The data-bp attribute.
- */
-function bp_nouveau_search_object_data_attr( $attr = '' ) {
-	$objects = bp_nouveau_get_search_objects();
-
-	if ( ! isset( $objects['secondary'] ) ) {
-		return $attr;
-	}
-
-	if ( bp_is_active( 'groups' ) && bp_is_group_members() ) {
-		$attr = join( '_', $objects );
-	} else {
-		$attr = $objects['secondary'];
-	}
-
-	echo esc_attr( $attr );
+	echo esc_attr( $class );
 }
 
 /**
@@ -1543,8 +1545,9 @@ function bp_nouveau_search_object_data_attr( $attr = '' ) {
  *
  * @since 1.0.0
  *
- * @param  string $suffix A string to append at the end of the ID.
- * @param  string $sep    The separator to use between each token.
+ * @param string $suffix A string to append at the end of the ID.
+ * @param string $sep    The separator to use between each token.
+ *
  * @return string The selector ID.
  */
 function bp_nouveau_search_selector_id( $suffix = '', $sep = '-' ) {
@@ -1565,7 +1568,7 @@ function bp_nouveau_search_selector_id( $suffix = '', $sep = '-' ) {
 function bp_nouveau_search_selector_name( $suffix = '', $sep = '_' ) {
 	$objects = bp_nouveau_get_search_objects();
 
-	if ( isset( $objects['secondary'] ) && empty( $suffix ) ) {
+	if ( isset( $objects['secondary'] ) && ! $suffix ) {
 		$name = bp_core_get_component_search_query_arg( $objects['secondary'] );
 	} else {
 		$name = join( $sep, array_merge( $objects, (array) $suffix ) );
@@ -1601,20 +1604,16 @@ function bp_nouveau_search_default_text( $text = '', $is_attr = true ) {
  * Get the search form template part and fire some do_actions if needed.
  *
  * @since 1.0.0
- *
- * @return string HTML Output
  */
 function bp_nouveau_search_form() {
 	bp_get_template_part( 'common/search/search-form' );
 
 	$objects = bp_nouveau_get_search_objects();
-
 	if ( empty( $objects['primary'] ) || empty( $objects['secondary'] ) ) {
 		return;
 	}
 
 	if ( 'dir' === $objects['primary'] ) {
-
 		if ( 'activity' === $objects['secondary'] ) {
 			/**
 			 * Fires before the display of the activity syndication options.
@@ -1658,46 +1657,53 @@ function bp_nouveau_search_form() {
 	}
 }
 
+
 /** Template tags for the directory & user/group screen filters **********************************/
 
 /**
- * Get the current component or action
+ * Get the current component or action.
+ *
  * If on single group screens we need to switch from component
  * to bp_current_action() to add the correct id's/labels
  * for group/activity & similar screens.
- *
  */
+function bp_nouveau_current_object() {
+	/*
+	 * If we're looking at groups single screens we need to factor in current action
+	 * to avoid the component check adding the wrong id for the main dir e.g 'groups' instead of 'activity'.
+	 * We also need to check for group screens to adjust the id's for prefixes.
+	 */
+	$component = array();
 
-	function bp_nouveau_current_object() {
-		// If we're looking at groups single screens we need to factor in current action
-		// to avoid the component check adding the wrong id for the main dir e.g 'groups' instead of
-		// 'activity'.
-		// We also need to check for group screens to adjust the id's for prefixes.
+	if ( bp_is_group() ) {
+		$component['members_select']   = 'groups_members-order-select';
+		$component['members_order_by'] = 'groups_members-order-by';
+		$component['object']           = bp_current_action();
+		$component['data_filter']      = 'group_' . bp_current_action();
 
-		$component = array();
-
-		if ( bp_is_group() ) :
-			$component['members_select']   = 'groups_members-order-select';
-			$component['members_order_by'] = 'groups_members-order-by';
-			$component['object']        = bp_current_action();
-			$component['data_filter']   = 'group_' . bp_current_action();
-
-		else:
-			$component['members_select']   = 'members-order-select';
-			$component['members_order_by'] = 'members-order-by';
-			$component['object']       = bp_current_component();
-			$component['data_filter']  = bp_current_component();
-		endif;
-
-		return $component;
+	} else {
+		$component['members_select']   = 'members-order-select';
+		$component['members_order_by'] = 'members-order-by';
+		$component['object']           = bp_current_component();
+		$component['data_filter']      = bp_current_component();
 	}
 
-function bp_nouveau_filter_container_id() {
-	echo bp_nouveau_get_filter_container_id();
+	return $component;
 }
 
-	function bp_nouveau_get_filter_container_id() {
+/**
+ * Output data filter container's ID attribute value.
+ */
+function bp_nouveau_filter_container_id() {
+	echo esc_attr( bp_nouveau_get_filter_container_id() );
+}
 
+	/**
+	 * Get data filter container's ID attribute value.
+	 *
+	 * @param string
+	 */
+	function bp_nouveau_get_filter_container_id() {
 		$component = bp_nouveau_current_object();
 
 		$ids = array(
@@ -1710,16 +1716,25 @@ function bp_nouveau_filter_container_id() {
 		);
 
 		if ( isset( $ids[ $component['object'] ] ) ) {
-			return esc_attr( apply_filters( 'bp_nouveau_get_filter_container_id', $ids[ $component['object'] ] ) );
+			return apply_filters( 'bp_nouveau_get_filter_container_id', $ids[ $component['object'] ] );
 		}
+
+		return '';
 	}
 
+/**
+ * Output data filter's ID attribute value.
+ */
 function bp_nouveau_filter_id() {
-	echo bp_nouveau_get_filter_id();
+	echo esc_attr( bp_nouveau_get_filter_id() );
 }
 
+	/**
+	 * Get data filter's ID attribute value.
+	 *
+	 * @param string
+	 */
 	function bp_nouveau_get_filter_id() {
-
 		$component = bp_nouveau_current_object();
 
 		$ids = array(
@@ -1731,73 +1746,88 @@ function bp_nouveau_filter_id() {
 			'blogs'         => 'blogs-order-by',
 		);
 
-
-
 		if ( isset( $ids[ $component['object'] ] ) ) {
-			return esc_attr( apply_filters( 'bp_nouveau_get_filter_id', $ids[ $component['object'] ] ) );
+			return apply_filters( 'bp_nouveau_get_filter_id', $ids[ $component['object'] ] );
 		}
+
+		return '';
 	}
 
+/**
+ * Output data filter's label.
+ */
 function bp_nouveau_filter_label() {
-	echo bp_nouveau_get_filter_label();
+	echo esc_html( bp_nouveau_get_filter_label() );
 }
 
+	/**
+	 * Get data filter's label.
+	 *
+	 * @param string
+	 */
 	function bp_nouveau_get_filter_label() {
-
 		$component = bp_nouveau_current_object();
-
-		$label = __( 'Order By:', 'buddypress' );
+		$label     = __( 'Order By:', 'buddypress' );
 
 		if ( 'activity' === $component['object'] || 'friends' === $component['object'] ) {
 			$label = __( 'Show:', 'buddypress' );
 		}
 
-		return esc_html( apply_filters( 'bp_nouveau_get_filter_label', $label ) );
+		return apply_filters( 'bp_nouveau_get_filter_label', $label );
 	}
 
+/**
+ * Output data filter's data-bp-filter attribute value.
+ */
 function bp_nouveau_filter_component() {
 	$component = bp_nouveau_current_object();
 	echo esc_attr( $component['data_filter'] );
 }
 
+/**
+ * Output the <option> of the data filter's <select> element.
+ */
 function bp_nouveau_filter_options() {
-	echo bp_nouveau_get_filter_options();
+	echo bp_nouveau_get_filter_options();  // Escaped in inner functions.
 }
 
+	/**
+	 * Get the <option> of the data filter's <select> element.
+	 *
+	 * @return string
+	 */
 	function bp_nouveau_get_filter_options() {
-
-	if ( 'notifications' === bp_current_component() ) :
-			bp_nouveau_notifications_filters();
-		return;
-
-	else:
-		$filters = bp_nouveau_get_component_filters();
-
 		$output = '';
 
-		foreach ( $filters as $key => $value ) {
-			$output .= sprintf( '<option value="%1$s">%2$s</option>%3$s',
-				esc_attr( $key ),
-				esc_html( $value ),
-				"\n"
-			);
+		if ( 'notifications' === bp_current_component() ) {
+			$output = bp_nouveau_get_notifications_filters();
 
+		} else {
+			$filters = bp_nouveau_get_component_filters();
+
+			foreach ( $filters as $key => $value ) {
+				$output .= sprintf( '<option value="%1$s">%2$s</option>%3$s',
+					esc_attr( $key ),
+					esc_html( $value ),
+					"\n"
+				);
+			}
 		}
 
 		return $output;
-
-	endif;
 	}
 
-/** Template tags for the customizer ******************************************/
+
+/** Template tags for the Customizer ******************************************/
 
 /**
  * Get a link to reach a specific section into the customizer
  *
  * @since 1.0.0
  *
- * @param  array  $args The argument to customize the Customizer link
- * @return string HTML Output
+ * @param array $args Optional. The argument to customize the Customizer link.
+ *
+ * @return string HTML.
  */
 function bp_nouveau_get_customizer_link( $args = array() ) {
 	$r = bp_parse_args( $args, array(
@@ -1816,13 +1846,18 @@ function bp_nouveau_get_customizer_link( $args = array() ) {
 		return '';
 	}
 
+	$url = '';
+
 	if ( bp_is_user() ) {
 		$url = rawurlencode( bp_displayed_user_domain() );
+
 	} elseif ( bp_is_group() ) {
 		$url = rawurlencode( bp_get_group_permalink( groups_get_current_group() ) );
+
 	} elseif ( ! empty( $r['object'] ) && ! empty( $r['item_id'] ) ) {
 		if ( 'user' === $r['object'] ) {
 			$url = rawurlencode( bp_core_get_user_domain( $r['item_id'] ) );
+
 		} elseif ( 'group' === $r['object'] ) {
 			$group = groups_get_group( array( 'group_id' => $r['item_id'] ) );
 
@@ -1832,7 +1867,7 @@ function bp_nouveau_get_customizer_link( $args = array() ) {
 		}
 	}
 
-	if ( empty( $url ) ) {
+	if ( ! $url ) {
 		return '';
 	}
 
@@ -1841,7 +1876,7 @@ function bp_nouveau_get_customizer_link( $args = array() ) {
 		'url'                => $url,
 	), admin_url( 'customize.php' ) );
 
-	return sprintf( '<a href="%1$s">%2$s</a>', esc_url( $customizer_link ), $r['text'] );
+	return sprintf( '<a href="%1$s">%2$s</a>', esc_url( $customizer_link ), esc_html( $r['text'] ) );
 }
 
 /** Template tags for signup forms *******************************************/
@@ -1850,21 +1885,23 @@ function bp_nouveau_get_customizer_link( $args = array() ) {
  * Fire specific hooks into the register template
  *
  * @since 1.0.0
+ * @since 1.2.4 Adds the 'bp_before_signup_profile_fields' action hook
+ * @since 1.9.0 Adds the 'bp_signup_profile_fields' action hook
  *
- * @param string $when    'before' or 'after'
- * @param string $prefix  Use it to add terms before the hook name
+ * @param string $when   'before' or 'after'
+ * @param string $prefix Use it to add terms before the hook name
  */
 function bp_nouveau_signup_hook( $when = '', $prefix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( ! $when ) {
 		$hook[] = $when;
 	}
 
-	if ( ! empty( $prefix ) ) {
+	if ( ! $prefix ) {
 		if ( 'page' === $prefix ) {
 			$hook[] = 'register';
-		} elseif ( 'steps' === $prefix  ) {
+		} elseif ( 'steps' === $prefix ) {
 			$hook[] = 'signup';
 		}
 
@@ -1875,11 +1912,6 @@ function bp_nouveau_signup_hook( $when = '', $prefix = '' ) {
 		$hook[] = 'fields';
 	}
 
-	/**
-	 * @since 1.1.0 (BuddyPress)
-	 * @since 1.2.4 (BuddyPress) Adds the 'bp_before_signup_profile_fields' action hook
-	 * @since 1.9.0 (BuddyPress) Adds the 'bp_signup_profile_fields' action hook
-	 */
 	bp_nouveau_hook( $hook );
 }
 
@@ -1888,19 +1920,19 @@ function bp_nouveau_signup_hook( $when = '', $prefix = '' ) {
  *
  * @since 1.0.0
  *
- * @param string $when    'before' or 'after'
- * @param string $prefix  Use it to add terms before the hook name
+ * @param string $when   'before' or 'after'
+ * @param string $prefix Use it to add terms before the hook name
  */
 function bp_nouveau_activation_hook( $when = '', $suffix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( ! $when ) {
 		$hook[] = $when;
 	}
 
 	$hook[] = 'activate';
 
-	if ( ! empty( $suffix ) ) {
+	if ( ! $suffix ) {
 		$hook[] = $suffix;
 	}
 
@@ -1908,9 +1940,6 @@ function bp_nouveau_activation_hook( $when = '', $suffix = '' ) {
 		$hook[2] = 'activation';
 	}
 
-	/**
-	 * @since 1.1.0 (BuddyPress)
-	 */
 	bp_nouveau_hook( $hook );
 }
 
@@ -1919,13 +1948,11 @@ function bp_nouveau_activation_hook( $when = '', $suffix = '' ) {
  *
  * @since 1.0.0
  *
- * @param  string     $section The section of fields to get 'account_details' or 'blog_details'. Required.
- *                             Default: 'account_details'.
- * @return string              HTML Output.
+ * @param string section The section of fields to get 'account_details' or 'blog_details'. Required.
+ *                 v     Default: 'account_details'.
  */
 function bp_nouveau_signup_form( $section = 'account_details' ) {
 	$fields = bp_nouveau_get_signup_fields( $section );
-
 	if ( ! $fields ) {
 		return;
 	}
@@ -1992,7 +2019,7 @@ function bp_nouveau_signup_form( $section = 'account_details' ) {
 		if ( ! empty( $class ) ) {
 			// In case people are adding classes..
 			$classes = explode( ' ', $class );
-			$class = ' class="' . join( ' ', array_map( 'sanitize_html_class', $classes ) ) . '"';
+			$class = ' class="' . esc_attr( join( ' ', array_map( 'sanitize_html_class', $classes ) ) ) . '"';
 		}
 
 		// Do not fire the do_action to display errors for the private radio.
@@ -2006,22 +2033,23 @@ function bp_nouveau_signup_form( $section = 'account_details' ) {
 		}
 
 		// Set the input.
-		$field_output = sprintf( '<input type="%1$s" name="%2$s" id="%3$s"%4$s value="%5$s"%6$s/>',
+		$field_output = sprintf( '<input type="%1$s" name="%2$s" id="%3$s" %4$s value="%5$s" %6$s />',
 			esc_attr( $type ),
 			esc_attr( $name ),
 			esc_attr( $id ),
-			$class,
+			$class,  // Constructed safely above.
 			esc_attr( $value ),
-			$attribute_type
+			$attribute_type // Constructed safely above.
 		);
 
 		// Not a radio, let's output the field
 		if ( 'radio' !== $type ) {
 			if ( 'signup_blog_url' !== $name ) {
-				print( $field_output );
+				print( $field_output );  // Constructed safely above.
 
 			// If it's the signup blog url, it's specific to Multisite config.
 			} elseif ( is_subdomain_install() ) {
+				// Constructed safely above.
 				printf( '%1$s %2$s . %3$s',
 					is_ssl() ? 'https://' : 'http://',
 					$field_output,
@@ -2032,12 +2060,13 @@ function bp_nouveau_signup_form( $section = 'account_details' ) {
 			} else {
 				printf( '%1$s %2$s',
 					home_url( '/' ),
-					$field_output
+					$field_output  // Constructed safely above.
 				);
 			}
 
 		// It's a radio, let's output the field inside the label
 		} else {
+			// $label_output and $field_output are constructed safely above.
 			printf( $label_output, esc_attr( $name ), $field_output . ' ' . esc_html( $label ) );
 		}
 
@@ -2060,12 +2089,10 @@ function bp_nouveau_signup_form( $section = 'account_details' ) {
  *
  * @since 1.0.0
  *
- * @param  string $action The action to get the submit button for. Required.
- * @return string         HTML Output.
+ * @param string $action The action to get the submit button for. Required.
  */
-function bp_nouveau_submit_button( $action = '' ) {
+function bp_nouveau_submit_button( $action ) {
 	$submit_data = bp_nouveau_get_submit_button( $action );
-
 	if ( empty( $submit_data['attributes'] ) || empty( $submit_data['nonce'] ) ) {
 		return;
 	}
@@ -2077,12 +2104,11 @@ function bp_nouveau_submit_button( $action = '' ) {
 	// Output the submit button.
 	printf( '
 		<div class="submit">
-			<input type="submit"%s/>
+			<input type="submit" %s/>
 		</div>',
-		bp_get_form_field_attributes( 'submit', $submit_data['attributes'] )
+		bp_get_form_field_attributes( 'submit', $submit_data['attributes'] )  // Safe.
 	);
 
-	// Output the nonce field
 	wp_nonce_field( $submit_data['nonce'] );
 
 	if ( ! empty( $submit_data['after'] ) ) {

--- a/bp-templates/bp-nouveau/includes/xprofile/template-tags.php
+++ b/bp-templates/bp-nouveau/includes/xprofile/template-tags.php
@@ -11,44 +11,39 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Fire specific hooks into the single members xprofile templates
+ * Fire specific hooks into the single members xprofile templates.
  *
  * @since 1.0.0
+ * @since 1.1.0 (BuddyPress) for the 'avatar_upload_content', 'edit_content', 'field_content',
+ *                           'field_item', 'field_buttons', 'profile_content' suffixes.
+ * @since 1.2.0 (BuddyPress) for the 'loop_content' suffix.
+ * @since 2.4.0 (BuddyPress) for the 'edit_cover_image' suffix.
  *
- * @param string $when    'before' or 'after'
- * @param string $suffix  Use it to add terms at the end of the hook name
+ * @param string $when   Either 'before' or 'after'.
+ * @param string $suffix Use it to add terms at the end of the hook name
  */
 function bp_nouveau_xprofile_hook( $when = '', $suffix = '' ) {
 	$hook = array( 'bp' );
 
-	if ( ! empty( $when ) ) {
+	if ( $when ) {
 		$hook[] = $when;
 	}
 
 	// It's a xprofile hook
 	$hook[] = 'profile';
 
-	if ( ! empty( $suffix ) ) {
+	if ( $suffix ) {
 		$hook[] = $suffix;
 	}
 
-	/**
-	 * @since 1.1.0 (BuddyPress) for the 'avatar_upload_content', 'edit_content', 'field_content',
-	 *                           'field_item', 'field_buttons', 'profile_content' suffixes.
-	 * @since 1.2.0 (BuddyPress) for the 'loop_content' suffix.
-	 * @since 2.4.0 (BuddyPress) for the 'edit_cover_image' suffix.
-	 */
 	bp_nouveau_hook( $hook );
 }
 
 
 /**
- * Template tag to output the field visibility markup in
- * edit and signup screens.
+ * Template tag to output the field visibility markup in edit and signup screens.
  *
  * @since 1.0.0
- *
- * @return string HTML Output
  */
 function bp_nouveau_xprofile_edit_visibilty() {
 	/**
@@ -73,7 +68,6 @@ function bp_nouveau_xprofile_edit_visibilty() {
  * profile fields added to it for the registration screen.
  *
  * @since 1.0.0
- *
  */
 function bp_nouveau_base_account_has_xprofile() {
 	return (bool) bp_has_profile( array( 'profile_group_id' => 1, 'fetch_field_data' => false ) );


### PR DESCRIPTION
The first thing I wanted to do was removing the early escaping from the "get" template-tag functions, so I picked on the template-tag files within each folder, and went through.

Code quality was generally between "acceptable" to "good", and I'm happy to discuss any specific questions these proposed changes might raise, but for brevity, I've left that kind of reply out this request.